### PR TITLE
[mytracks/pgadmin-helm-chart] Support for kubernetes secrets

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.8
+version: 1.2.9
 appVersion: 4.19.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/helm-charts

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -59,9 +59,12 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `ingress.hosts.path` | Ingress path mapping | `` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `extraConfigmapMounts` | Additional configMap volume mounts for pgadmin4 pod | `[]` |
+| `extraSecretMounts` | Additional secret volume mounts for pgadmin4 pod | `[]` |
 | `extraContainers` | Sidecar containers to add to the pgadmin4 pod  | `{}` |
+| `extraInitContainers` | Sidecar init containers to add to the pgadmin4 pod  | `{}` |
 | `env.email` | pgAdmin4 default email | `chart@example.local` |
 | `env.password` | pgAdmin4 default password | `SuperSecret` |
+| `env.pgpassfile` | Path to pgpasssfile (optional)  | `` |
 | `persistentVolume.enabled` | If true, pgAdmin4 will create a Persistent Volume Claim | `true` |
 | `persistentVolume.accessMode` | Persistent Volume access Mode | `ReadWriteOnce` |
 | `persistentVolume.size` | Persistent Volume size | `10Gi` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
               mountPath: /var/lib/pgadmin
           securityContext:
             runAsUser: 0
+    {{- with .Values.extraInitContainers }}
+      {{ tpl . $ | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -62,10 +65,18 @@ spec:
               value: !!string {{ .Values.env.enhanced_cookie_protection }}
             - name: PGADMIN_DEFAULT_EMAIL
               value: {{ .Values.env.email }}
+          {{- if .Values.env.pgpassfile }}
+            - name: PGPASSFILE
+              value: {{ .Values.env.pgpassfile }}
+          {{- end }}
             - name: PGADMIN_DEFAULT_PASSWORD
               valueFrom:
                 secretKeyRef:
+          {{- if not .Values.existingSecret }}
                   name: {{ $fullName }}
+          {{- else }}
+                  name: {{ .Values.existingSecret }}
+          {{- end }}
                   key: password
           volumeMounts:
             - name: pgadmin-data
@@ -76,6 +87,12 @@ spec:
               subPath: servers.json
           {{- end }}
           {{- range .Values.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath | default "" }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.extraSecretMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
               subPath: {{ .subPath | default "" }}
@@ -98,6 +115,13 @@ spec:
         - name: {{ .name }}
           configMap:
             name: {{ .configMap }}
+            defaultMode: {{ .defaultMode | default 256 }}
+      {{- end }}
+      {{- range .Values.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secret }}
+            defaultMode: {{ .defaultMode | default 256 }}
       {{- end }}
       {{- if .Values.serverDefinitions.enabled }}
         - name: definitions


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds support for the following objects that I needed to read data from kubernetes secrets:
- extraInitContainers
- extraSecretMounts

Additionally I added the possiblilty to set the PGPASSFILE environment variable. This is also needed to read password from a kubernetes secret.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[mychartname]`)
