### PR TITLE
[runix/pgadmin4] fix: fix mispelling value imagePullSecrets

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.9
+version: 1.2.10
 appVersion: 4.19.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/helm-charts

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
       {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- .Values.iamgePullSecrets | toYaml | nindent 8 }}
+        {{- .Values.imagePullSecrets | toYaml | nindent 8 }}
     {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
It fixes a mispelling of imagePullSecrets.

Before in order to define an imagePullSecret to pull the image we had to define two variables :
 - imagePullSecrets
 - iamgePullSecrets

Renaming iamgePullSecrets to imagePullSecrets solves this.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
