### PR TITLE
[pgadmin4]: Use correct port in network policy

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.13
+version: 1.2.14
 appVersion: 4.20.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/helm-charts

--- a/charts/pgadmin4/templates/networkpolicy.yaml
+++ b/charts/pgadmin4/templates/networkpolicy.yaml
@@ -14,4 +14,4 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   ingress:
   - ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ .Values.service.targetPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Network policies should be applied for container ports, rather than service ports. Service ports can be different than container ports.

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
