### PR TITLE
initContainers, volume permissions and extra init

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.14
+version: 1.2.15
 appVersion: 4.20.0
 home: https://www.pgadmin.org/
 source: https://github.com/rowanruseler/helm-charts

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -73,6 +73,8 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `resources` | CPU/memory resource requests/limits | `{}` |
 | `livenessProbe` | [liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `readinessProbe` | [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
+| `VolumePermissions.enabled` | Enables init container that changes volume permissions in the data directory  | `false` |
+| `extraInitContainers` | Init containers to launch alongside the app | `[]` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |
 | `affinity` | Node affinity for pod assignment | `{}` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -31,7 +31,8 @@ spec:
     {{- end }}
     spec:
       initContainers:
-        - name: init-pgadmin
+      {{- if .Values.VolumePermissions.enabled }}
+        - name: init-chmod-data
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/bin/chown", "-R", "5050:5050", "/var/lib/pgadmin"]
@@ -40,9 +41,11 @@ spec:
               mountPath: /var/lib/pgadmin
           securityContext:
             runAsUser: 0
-    {{- with .Values.extraInitContainers }}
-      {{ tpl . $ | nindent 8 }}
-    {{- end }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
+        {{ tpl . $ | nindent 8 }}
+        - name
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -200,6 +200,18 @@ readinessProbe:
   successThreshold: 1
   failureThreshold: 3
 
+## Required to be enabled pre pgAdmin4 4.16 release, to set the ACL on /var/lib/pgadmin.
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+##
+VolumePermissions:
+  ## If true, enables an InitContainer to set permissions on /var/lib/pgadmin.
+  ##
+  enabled: true
+
+## Additional InitContainers to initialize the pod
+##
+extraInitContainers: []
+
 ## Node labels for pgAdmin4 pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -206,7 +206,7 @@ readinessProbe:
 VolumePermissions:
   ## If true, enables an InitContainer to set permissions on /var/lib/pgadmin.
   ##
-  enabled: true
+  enabled: false
 
 ## Additional InitContainers to initialize the pod
 ##


### PR DESCRIPTION
VolumePermissions:
  Pre the release of version 4.16, volume permissions had to be adjusted
  or pgAdmin4 would error out on:
    * PermissionError: [Errno 13] Permission denied: '/var/log/pgadmin'

  By default it is now disabled, since version 4.16 and up it will show
  a warning and functions without the permissions adjustment.

ExtraInitContainers:
  This value was already added in the templates/deployment but never
  documentated nor added in the values.yaml file.

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>
