### PR TITLE
version upgrade from 4.20 to 4.21

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,9 +1,15 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.15
-appVersion: 4.20.0
+version: 1.2.16
+appVersion: 4.21.0
+keywords:
+  - pgadmin
+  - postgres
+  - database
+  - sql
 home: https://www.pgadmin.org/
+icon: https://wiki.postgresql.org/images/3/30/PostgreSQL_logo.3colors.120x120.png
 source: https://github.com/rowanruseler/helm-charts
 maintainers:
   - name: rowanruseler

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -43,7 +43,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | --------- | ----------- | ------- |
 | `replicaCount` | Number of pgadmin4 replicas | `1` |
 | `image.repository` | Docker image | `dpage/pgadmin4` |
-| `image.tag` | Docker image tag | `4.20` |
+| `image.tag` | Docker image tag | `"4.21"` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.port` | Service port | `80` |

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 ##
 image:
   repository: dpage/pgadmin4
-  tag: "4.20"
+  tag: "4.21"
   pullPolicy: IfNotPresent
 
 service:
@@ -32,7 +32,7 @@ strategy: {}
 
 ## Server definitions will be loaded at launch time. This allows connection
 ## information to be pre-loaded into the instance of pgAdmin4 in the container.
-## Ref: https://www.pgadmin.org/docs/pgadmin4/4.13/import_export_servers.html
+## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/import_export_servers.html
 ##
 serverDefinitions:
   ## If true, server definitions will be created
@@ -63,7 +63,7 @@ ingress:
     #
     ## When setting `ingress.hosts.paths`, pgAdmin needs additional header
     ## to be passed.
-    ## Ref: https://www.pgadmin.org/docs/pgadmin4/4.20/container_deployment.html#http-via-nginx
+    ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#http-via-nginx
     # nginx.ingress.kubernetes.io/configuration-snippet: |
     #   proxy_set_header X-Script-Name /pgadmin4;
     #
@@ -127,11 +127,13 @@ env:
   password: SuperSecret
 
   ## If True, allows pgAdmin4 to create session cookies based on IP address
-  ## Ref: https://www.pgadmin.org/docs/pgadmin4/4.18/config_py.html
+  ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html
   ##
   enhanced_cookie_protection: "False"
 
   ## Add custom environment variables that will be injected to deployment
+  ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html
+  ##
   variables: []
   # - name: PGADMIN_LISTEN_ADDRESS
   #   value: "0.0.0.0"


### PR DESCRIPTION
Adjusted the version from 4.20 toward 4.21, and adjusted some links that
had previous version release documentation to `latest`.

Also updated the Chart.yaml with keywords and icon for Helm Hub.

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>