### PR TITLE
[pgadmin4] Update ingress example to match version `4.21`

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.17
+version: 1.2.18
 appVersion: 4.21.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -67,11 +67,12 @@ ingress:
     # nginx.ingress.kubernetes.io/configuration-snippet: |
     #   proxy_set_header X-Script-Name /pgadmin4;
     #
-    ## If TLS is terminated elsewhere (on external load balancer),
-    ## you may want to redirect to `https://` URL scheme.
+    ## If TLS is terminated elsewhere (on external load balancer), you may want
+    ## to redirect to `https://` URL scheme along with rewriting URL path if
+    ## `ingress.hosts.paths` is set. This is specific for image version `4.21`.
     ## Ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
-    # nginx.ingress.kubernetes.io/proxy-redirect-from: "~^(http://)(.+)$"
-    # nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$2"
+    # nginx.ingress.kubernetes.io/proxy-redirect-from: "~^http://([^/]+)/$"
+    # nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$1/pgadmin4/"
     ##
     # kubernetes.io/tls-acme: "true"
 


### PR DESCRIPTION
#### What this PR does / why we need it:
It looks like that previously used proxy redirect rule for ingress no longer works for new pgAdmin version `4.21`, causing the application to ignore custom URL path right after logging in.
This PR fixes regex to ensure correct behavior.

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
