### PR TITLE
[pgadmin4] Fix HTTPS URL relative path redirects for v4.22

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.21
+version: 1.2.22
 appVersion: 4.22.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -69,11 +69,14 @@ ingress:
     #
     ## If TLS is terminated elsewhere (on external load balancer), you may want
     ## to redirect to `https://` URL scheme along with rewriting URL path if
-    ## `ingress.hosts.paths` is set. This is specific for image version `4.21`.
+    ## `ingress.hosts.paths` is set. This is specific for image version `4.22`.
     ## Ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
-    # nginx.ingress.kubernetes.io/proxy-redirect-from: "~^http://([^/]+)/$"
-    # nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$1/pgadmin4/"
-    ##
+    # nginx.ingress.kubernetes.io/proxy-redirect-from: "~^http://([^/]+)/(pgadmin4/)?(.*)$"
+    # nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$1/pgadmin4/$3"
+    #
+    ## Secure Ingress with kube-lego or cert-manager if they are deployed into
+    ## the cluster.
+    ## Ref: https://cert-manager.io/docs/usage/ingress/#optional-configuration
     # kubernetes.io/tls-acme: "true"
 
   ## pgAdmin4 Ingress hostnames with optional path


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR updates Ingress configuration example to work with version 4.22 of pgAdmin.
It covers the http:// to https:// redirection when relative URL path is used.
It also makes login in to pgAdmin working if only https is allowed for Ingress.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
