### PR TITLE
[pgadmin4] Fix quoting for non-string environment variables

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.22
+version: 1.2.23
 appVersion: 4.22.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -86,8 +86,8 @@ spec:
           {{- end }}
                   key: password
           {{- range .Values.env.variables }}
-            - name: {{ .name }}
-              value: {{ .value }}
+            - name: {{ .name | quote}}
+              value: {{ .value | quote }}
           {{- end }}
           volumeMounts:
             - name: pgadmin-data

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           {{- end }}
                   key: password
           {{- range .Values.env.variables }}
-            - name: {{ .name | quote}}
+            - name: {{ .name | quote }}
               value: {{ .value | quote }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
#### What this PR does / why we need it:
Currently, installing the chart fails in case of integer values in additional environment variables.
The Issue raised for this feature included a example which is mostly followed, except the quotation [1].
Added this.
Usually ints don't need to be quoted, except in environment vars [2].
[1]: https://github.com/helm/charts/blob/f2fcadaa5a1af57bbdf2e49a99f25c9589d5b540/stable/fluentd/templates/deployment.yaml#L68-L71
[2]: https://helm.sh/docs/howto/charts_tips_and_tricks/#quote-strings-dont-quote-integers

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
