### PR TITLE
[pgadmin4] Add init.resources

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.24
+version: 1.2.25
 appVersion: 4.22.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -82,6 +82,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `podAnnotations` | Annotations for pod | `{}` |
 | `existingSecret` | The name of an existing secret containing the pgadmin4 default password. | `""` |
 | `env.enhanced_cookie_protection` | Allows pgAdmin4 to create session cookies based on IP address | `"False"` |
+| `init.resources` | Init container CPU/memory resource requests/limits | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
               mountPath: /var/lib/pgadmin
           securityContext:
             runAsUser: 0
+          resources:
+            {{- .Values.init.resources | toYaml | nindent 12 }}
       {{- end }}
       {{- with .Values.extraInitContainers }}
         {{ tpl . $ | nindent 8 }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -240,3 +240,8 @@ affinity: {}
 ## Pod annotations
 ##
 podAnnotations: {}
+
+init:
+  ## Init container resources
+  ##
+  resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Some clusters require that all the containers have `resources` section defined in order to start.
This PR allows to set resources for the init container. 
#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
