### PR TITLE
[pgadmin4] Fix hardcode pgAdmin version label

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.2.25
+version: 1.2.26
 appVersion: 4.22.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -38,8 +38,8 @@ Common labels
 app.kubernetes.io/name: {{ include "pgadmin.name" . }}
 helm.sh/chart: {{ include "pgadmin.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- if .Values.image.tag }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

When you specify `image.tag` different that specified in Chart.yaml, resource label `app.kubernetes.io/version` show wrong version.

https://github.com/rowanruseler/helm-charts/blob/301772b7c61dcb7a005769ffa9863583e0445eaa/charts/pgadmin4/templates/_helpers.tpl#L42

This PR fix this behavior.

#### Which issue this PR fixes
  - fixes #37 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
