### PR TITLE
[pgadmin4] Fix definition of API for NetworkPolicy

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.3.0
+version: 1.3.1
 appVersion: 4.23.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Defines a JSON file containing server definitions. This allows connection inform
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "deployment.apiVersion" -}}
-{{- if semverCompare "<1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.9.0-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "apps/v1beta2" -}}
 {{- else -}}
 {{- print "apps/v1" -}}
@@ -88,7 +88,7 @@ Return the appropriate apiVersion for ingress.
 Return the appropriate apiVersion for network policy.
 */}}
 {{- define "networkPolicy.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare "<1.8.0-0" .Capabilities.KubeVersion.GitVersion -}}
 {{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR corects the usage of newer API for NetworkPolicy object in modern Kubernetes version.
The [Kubernetes blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) says that new `networking.k8s.io/v1` API version was available since v1.8.

#### Special notes for your reviewer:
Also fixed semver comparison for Helm v3 according to the docs:
https://helm.sh/docs/chart_template_guide/function_list/#semvercompare 

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[mychartname]`)
