### PR TITLE
[pgadmin4] Add Support For Context Path Hosting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         kubernetesVersion: ["v1.13.12", "v1.17.2"]
     runs-on: ubuntu-latest
-    # if: github.ref != 'refs/heads/master'
+    if: github.ref != 'refs/heads/master'
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         kubernetesVersion: ["v1.13.12", "v1.17.2"]
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
+    # if: github.ref != 'refs/heads/master'
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,38 +11,27 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-
+      uses: actions/checkout@v1
     - name: Shellcheck
-      uses: ludeeus/action-shellcheck@1.0.0
-
-    # prerequisites for helm/chart-testing-action@v2.0.1
-    - name: Set up Helm
-      uses: azure/setup-helm@v1
-      with:
-        version: v3.3.0
-        # matches version used by helm/chart-testing-action@v2.0.1
-    - name: Set Up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
-
-    - name: Set up chart-testing
-      uses: helm/chart-testing-action@v2.0.1
-
-    - name: Run chart-testing (lint)
-      run: ct lint --lint-conf '.ci/ct-config.yaml'
-
+      uses: ludeeus/action-shellcheck@0.1.0
     - name: Install kind
-      uses: helm/kind-action@v1.1.0
+      uses: helm/kind-action@v1.0.0-alpha.3
       with:
         node_image: "kindest/node:${{ matrix.kubernetesVersion }}"
         config: .ci/kind-config.yaml
+        install_local_path_provisioner: true
     - name: Verify kind
       run: |
         kubectl cluster-info
         kubectl get nodes -o wide
         kubectl get pods -n kube-system
-    
+    - name: Run chart-testing (lint)
+      uses: helm/chart-testing-action@v1.0.0-alpha.3
+      with:
+        command: lint
+        config: .ci/ct-config.yaml
     - name: Run chart-testing (install)
-      run: ct install --config '.ci/ct-config.yaml'
+      uses: helm/chart-testing-action@v1.0.0-alpha.3
+      with:
+        command: install
+        config: .ci/ct-config.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,27 +11,38 @@ jobs:
     if: github.ref != 'refs/heads/master'
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
+
     - name: Shellcheck
-      uses: ludeeus/action-shellcheck@0.1.0
+      uses: ludeeus/action-shellcheck@1.0.0
+
+    # prerequisites for helm/chart-testing-action@v2.0.1
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.3.0
+        # matches version used by helm/chart-testing-action@v2.0.1
+    - name: Set Up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.0.1
+
+    - name: Run chart-testing (lint)
+      run: ct lint --lint-conf '.ci/ct-config.yaml'
+
     - name: Install kind
-      uses: helm/kind-action@v1.0.0-alpha.3
+      uses: helm/kind-action@v1.1.0
       with:
         node_image: "kindest/node:${{ matrix.kubernetesVersion }}"
         config: .ci/kind-config.yaml
-        install_local_path_provisioner: true
     - name: Verify kind
       run: |
         kubectl cluster-info
         kubectl get nodes -o wide
         kubectl get pods -n kube-system
-    - name: Run chart-testing (lint)
-      uses: helm/chart-testing-action@v1.0.0-alpha.3
-      with:
-        command: lint
-        config: .ci/ct-config.yaml
+    
     - name: Run chart-testing (install)
-      uses: helm/chart-testing-action@v1.0.0-alpha.3
-      with:
-        command: install
-        config: .ci/ct-config.yaml
+      run: ct install --config '.ci/ct-config.yaml'

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.4.1
+version: 1.4.2
 appVersion: 4.29.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.4.2.1
+version: 1.4.2
 appVersion: 4.29.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.4.2
+version: 1.4.2.1
 appVersion: 4.29.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -71,6 +71,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `env.email` | pgAdmin4 default email. Needed chart reinstall for apply changes | `chart@example.local` |
 | `env.password` | pgAdmin4 default password. Needed chart reinstall for apply changes | `SuperSecret` |
 | `env.pgpassfile` | Path to pgpasssfile (optional). Needed chart reinstall for apply changes | `` |
+| `env.contextPath` | Context path for accessing pgadmin (optional) | `` |
 | `persistentVolume.enabled` | If true, pgAdmin4 will create a Persistent Volume Claim | `true` |
 | `persistentVolume.accessMode` | Persistent Volume access Mode | `ReadWriteOnce` |
 | `persistentVolume.size` | Persistent Volume size | `10Gi` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -58,14 +58,22 @@ spec:
         {{- if .Values.livenessProbe }}
           livenessProbe:
             httpGet:
+              {{- if .Values.env.contextPath }}
+              path: "{{ .Values.env.contextPath }}/misc/ping"
+              {{- else }}
               path: /misc/ping
+              {{- end }}
               port: 80
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:
+              {{- if .Values.env.contextPath }}
+              path: "{{ .Values.env.contextPath }}/misc/ping"
+              {{- else }}
               path: /misc/ping
+              {{- end }}
               port: 80
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
@@ -87,6 +95,10 @@ spec:
                   name: {{ .Values.existingSecret }}
           {{- end }}
                   key: password
+          {{- if .Values.env.contextPath }}
+            - name: SCRIPT_NAME
+              value: {{ .Values.env.contextPath }}
+          {{- end }}
           {{- range .Values.env.variables }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -148,6 +148,9 @@ env:
   email: chart@example.local
   password: SuperSecret
   # pgpassfile: /var/lib/pgadmin/storage/pgadmin/file.pgpass
+  
+  # set context path for application (e.g. /pgadmin4/*)
+  # contextPath: /pgadmin4
 
   ## If True, allows pgAdmin4 to create session cookies based on IP address
   ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html


### PR DESCRIPTION
#### What this PR does / why we need it:
Implements "one-change" support for hosting pgadmin4 on a context path (e.g. mydomain.com/pgadmin).

#### Special notes for your reviewer:
Documentation on [pgadmin.org](https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#http-via-nginx) demonstrates (sort of) how pgadmin4 can be hosted on a subdirectory/context path by adding the environment variable `SCRIPT_PATH`. However, since the request paths for the `readinessProbe` and `livenessProbe` are hard coded, modifications are needed to the helm chart to implement.

To make it more clear what this option does, I named the value field `contextPath`.

I have tested these modifications using `kustomize`, and have also verified that helm builds correctly with these modifications.

I'm not entirely certain whether placing this option underneath the environment variables section is logical, or desired for future extensibility. Additionally, not certain what the standards are for for increasing chart version numbers (minor vs dot version?). Would definitely appreciate feedback on these matters.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)