### PR TITLE
[pgadmin4] Fix deployment and test lint warnings

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.4.1
+version: 1.4.3
 appVersion: 4.29.0
 keywords:
   - pgadmin
@@ -10,7 +10,8 @@ keywords:
   - sql
 home: https://www.pgadmin.org/
 icon: https://wiki.postgresql.org/images/3/30/PostgreSQL_logo.3colors.120x120.png
-source: https://github.com/rowanruseler/helm-charts
+sources:
+  - https://github.com/rowanruseler/helm-charts
 maintainers:
   - name: rowanruseler
     email: rowanruseler@gmail.com

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -91,6 +91,8 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `test.image.registry` | Docker image registry for test | `docker.io` |
 | `test.image.repository` | Docker image for test | `busybox` |
 | `test.image.tag` | Docker image tag for test| `latest` |
+| `test.resources` | CPU/memory resource requests/limits for test | `{}` |
+| `test.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for test Pod | `` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -49,6 +49,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `image.repository` | Docker image | `dpage/pgadmin4` |
 | `image.tag` | Docker image tag | `"4.29"` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
+| `annotations` | Deployment Annotations | `{}` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.annotations` | Service Annotations | `{}` |
 | `service.port` | Service port | `80` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -22,12 +22,12 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if or (not .Values.existingSecret) .Values.podAnnotations }}
       annotations:
-    {{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-    {{- end }}
-    {{- if not .Values.existingSecret }}
+      {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-    {{- end }}
+      {{- end }}
     {{- end }}
 
     spec:

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -29,7 +29,9 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
     {{- end }}
     {{- end }}
+
     spec:
+    {{- if or (.Values.VolumePermissions.enabled) .Values.extraInitContainers }}
       initContainers:
       {{- if .Values.VolumePermissions.enabled }}
         - name: init-chmod-data
@@ -47,6 +49,7 @@ spec:
       {{- with .Values.extraInitContainers }}
         {{ tpl . $ | nindent 8 }}
       {{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
+{{- if .Values.annotations }}
+  annotations:
+  {{- if .Values.annotations }}
+    {{- .Values.annotations | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/pgadmin4/templates/tests/test-connection.yaml
+++ b/charts/pgadmin4/templates/tests/test-connection.yaml
@@ -7,9 +7,18 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
+  securityContext:
+    runAsNonRoot: true
+  {{- if .Values.test.securityContext }}
+    {{- .Values.test.securityContext | toYaml | nindent 4 }}
+  {{- end }}
   containers:
     - name: wget
       image: "{{ .Values.test.image.registry }}/{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
       command: ['wget']
       args:  ['{{ include "pgadmin.fullname" . }}:{{ .Values.service.port }}']
+      resources:
+        {{- .Values.test.resources | toYaml | nindent 8 }}
+      securityContext:
+        readOnlyRootFilesystem: true
   restartPolicy: Never

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -10,6 +10,9 @@ image:
   tag: "4.29"
   pullPolicy: IfNotPresent
 
+## Deployment annotations
+annotations: {}
+
 service:
   type: ClusterIP
   port: 80

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -276,3 +276,16 @@ test:
     registry: docker.io
     repository: busybox
     tag: latest
+  ## Resources request/limit for test-connection Pod
+  resources: {}
+#     limits:
+#       cpu: 25m
+#       memory: 16Mi
+#     requests:
+#       cpu: 50m
+#       memory: 32Mi
+  ## Security context for test-connection Pod
+  securityContext:
+    runAsUser: 5051
+    runAsGroup: 5051
+    fsGroup: 5051


### PR DESCRIPTION
#### What this PR does / why we need it:
1. Not include empty `initContainers:` in `deployment.yaml` when no extra initContainer or volumePermission is defined.
2. Add `test.resources` and `test.securityContext` to fix lint warnings.
3. Add `annotations` for Deployment. 
     * Specifically, this allows adding `kube-linter` ignore-check annotations such as
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: pg-pgadmin4
  labels:
  annotations:
    ignore-check.kube-linter.io/no-read-only-root-fs: This deployment requires rw access
      to root filesystem
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname]`)
