### PR TITLE
[pgadmin4] ingress api version should be v1 by default

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.5.6
+version: 1.5.7
 appVersion: 5.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -85,10 +85,10 @@ Return the appropriate apiVersion for deployment.
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-{{- print "networking.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+{{- print "networking.k8s.io/v1" -}}
 {{- else -}}
-{{- print "extensions/v1beta1" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
The Ingress api version should be `networking.k8s.io/v1` by default and fallback to `networking.k8s.io/v1beta1 ` if v1 is not supported.
#### What this PR does / why we need it:

#### Which issue this PR fixes
  - fixes #88 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
