### PR TITLE
default template/ingress and values

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.5.7
+version: 1.5.8
 appVersion: 5.0
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -82,17 +82,6 @@ Return the appropriate apiVersion for deployment.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for ingress.
-*/}}
-{{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
-{{- print "networking.k8s.io/v1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 Return the appropriate apiVersion for network policy.
 */}}
 {{- define "networkPolicy.apiVersion" -}}

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -1,14 +1,19 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "pgadmin.fullname" . -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
-  {{- if .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
 {{- if .Values.ingress.tls }}
@@ -27,10 +32,10 @@ spec:
       http:
         paths:
         {{- range .paths }}
-          - path: {{ . }}
+          - path: {{ .path }}
             backend:
               serviceName: {{ $fullName }}
-              servicePort: http
+              servicePort: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -75,43 +75,17 @@ networkPolicy:
   enabled: true
 
 ingress:
-  ## If true, pgAdmin4 Ingress will be created
-  ##
   enabled: false
-
-  ## pgAdmin4 Ingress annotations
-  ##
   annotations: {}
-    ## Indicate that the ingress should be handled by NGINX controller
     # kubernetes.io/ingress.class: nginx
-    #
-    ## When setting `ingress.hosts.paths`, pgAdmin needs additional header
-    ## to be passed.
-    ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/container_deployment.html#http-via-nginx
-    # nginx.ingress.kubernetes.io/configuration-snippet: |
-    #   proxy_set_header X-Script-Name /pgadmin4;
-    #
-    ## If TLS is terminated elsewhere (on external load balancer), you may want
-    ## to redirect to `https://` URL scheme along with rewriting URL path if
-    ## `ingress.hosts.paths` is set. This is specific for image version >= 4.22.
-    ## Ref: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#proxy-redirect
-    # nginx.ingress.kubernetes.io/proxy-redirect-from: "~^http://([^/]+)/(pgadmin4/)?(.*)$"
-    # nginx.ingress.kubernetes.io/proxy-redirect-to: "https://$1/pgadmin4/$3"
-    #
-    ## Secure Ingress with kube-lego or cert-manager if they are deployed into
-    ## the cluster.
-    ## Ref: https://cert-manager.io/docs/usage/ingress/#optional-configuration
     # kubernetes.io/tls-acme: "true"
-
-  ## pgAdmin4 Ingress hostnames with optional path
-  ## Must be provided if Ingress is enabled
   hosts:
     - host: chart-example.local
-      paths: []
-        # - /pgadmin4
-
-  ## pgAdmin4 Ingress TLS configuration
-  ## Secrets must be manually created in the namespace
+      paths:
+        - path: /
+          backend:
+            serviceName: chart-example.local
+            servicePort: 80
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
To not make this chart to complicated, or to estranged of how helm
itself dictates example. I've decided to revert the default apiVersion of
ingress back towards networking.k8s.io/v1beta1 and also still make
version extensions/v1beta1 available. Once helm itself makes the default
example adjustment to suit apiVersion networking.k8s.io/v1, this chart
will reflex that.

Until then, I will make sure future adjustment will not be easily
merged without further testing it.

Be aware that previous values.yaml configurations need to be adjusted to
match the default helm ingress example. Biggest adjustment is how paths
are defined.

Also cleaned up some comments in the values file, since the values file
feels to cluttered with examples for my taste.

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>