### PR TITLE
[pgadmin4] Make container port configurable

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.6.8
+version: 1.6.9
 appVersion: 5.3
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.6.9
+version: 1.7.0
 appVersion: 5.3
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -88,6 +88,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `readinessProbe` | [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `VolumePermissions.enabled` | Enables init container that changes volume permissions in the data directory  | `false` |
 | `extraInitContainers` | Init containers to launch alongside the app | `[]` |
+| `containerPorts.http` | Sets http port inside pgadmin container | `80` |
 | `resources` | CPU/memory resource requests/limits | `{}` |
 | `autoscaling.enabled` | Enables Autoscaling | `false` |
 | `autoscaling.minReplicas` | Minimum amount of Replicas | `1` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -67,28 +67,28 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
         {{- if .Values.livenessProbe }}
           livenessProbe:
             httpGet:
+              port: http
               {{- if .Values.env.contextPath }}
               path: "{{ .Values.env.contextPath }}/misc/ping"
               {{- else }}
               path: /misc/ping
               {{- end }}
-              port: 80
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:
+              port: http
               {{- if .Values.env.contextPath }}
               path: "{{ .Values.env.contextPath }}/misc/ping"
               {{- else }}
               path: /misc/ping
               {{- end }}
-              port: 80
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
           env:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -229,6 +229,9 @@ extraInitContainers: |
 #     securityContext:
 #       runAsUser: 5050
 
+containerPorts:
+  http: 80
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Signed-off-by: Anselm Eberhardt <aeberhardt@dg-i.net>

#### What this PR does / why we need it:

Exposes the container port configuration as a variable. This makes it possible to use this chart with pgadmin containers which are not allowed to bind to low ports.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
