### PR TITLE
[pgadmin4] oauth2 example config

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.7.1
+version: 1.7.2
 appVersion: 5.5
 keywords:
   - pgadmin

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -30,7 +30,7 @@ type: Opaque
 stringData:
   config_local.py: |-
     MASTER_PASSWORD_REQUIRED = True
-    AUTHENTICATION_SOURCES = ['oauth2', 'insternal']
+    AUTHENTICATION_SOURCES = ['oauth2', 'internal']
     OAUTH2_AUTO_CREATE_USER = True
     OAUTH2_CONFIG = [
       {

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -30,17 +30,17 @@ type: Opaque
 stringData:
   config_local.py: |-
     MASTER_PASSWORD_REQUIRED = True
-    AUTHENTICATION_SOURCES = ['internal', 'oauth2']
+    AUTHENTICATION_SOURCES = ['oauth2', 'insternal']
     OAUTH2_AUTO_CREATE_USER = True
     OAUTH2_CONFIG = [
       {
           'OAUTH2_NAME': 'google',
           'OAUTH2_DISPLAY_NAME': 'Google',
           'OAUTH2_CLIENT_ID': '[your_client_id]',
-          'OAUTH2_CLIENT_SECRET': '[your_client_secret]',
-          'OAUTH2_TOKEN_URL': 'https://oauth2.googleapis.com/token',
+          'OAUTH2_CLIENT_SECRET': '[your_client_secret',
+          'OAUTH2_TOKEN_URL': 'https://www.googleapis.com/oauth2/v3/token',
           'OAUTH2_AUTHORIZATION_URL': 'https://accounts.google.com/o/oauth2/v2/auth',
-          'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/auth/',
+          'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/oauth2/v3/'
           'OAUTH2_USERINFO_ENDPOINT': 'userinfo',
           'OAUTH2_ICON': 'fa-google',
           'OAUTH2_BUTTON_COLOR': '#0000ff',

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -36,8 +36,8 @@ stringData:
       {
           'OAUTH2_NAME': 'google',
           'OAUTH2_DISPLAY_NAME': 'Google',
-          'OAUTH2_CLIENT_ID': 'client_id',
-          'OAUTH2_CLIENT_SECRET': 'client_secret',
+          'OAUTH2_CLIENT_ID': '[your_client_id]',
+          'OAUTH2_CLIENT_SECRET': '[your_client_secret]',
           'OAUTH2_TOKEN_URL': 'https://oauth2.googleapis.com/token',
           'OAUTH2_AUTHORIZATION_URL': 'https://accounts.google.com/o/oauth2/v2/auth',
           'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/auth/',

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -1,0 +1,60 @@
+#
+# values.yaml
+#
+
+# Add config_local.py file to set OAUTH2 configuration
+# For details check documentation
+# https://www.pgadmin.org/docs/pgadmin4/5.5/oauth2.html
+
+extraSecretMounts:
+  - name: config-local
+    secret: pgadmin4-config
+    subPath: config_local.py
+    mountPath: "/pgadmin4/config_local.py"
+    readOnly: true
+
+#
+# secrets.yaml
+# To setup Google OAUTH
+## https://support.google.com/googleapi/answer/6158849?hl=en#
+# To setup Github OAUTH
+## https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
+# redirect|callback URI to set:
+## https://pgadmin4.example.com/oauth2/authorize 
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: pgadmin4-config
+type: Opaque
+stringData:
+  config_local.py: |-
+    MASTER_PASSWORD_REQUIRED = True
+    AUTHENTICATION_SOURCES = ['internal', 'oauth2']
+    OAUTH2_AUTO_CREATE_USER = True
+    OAUTH2_CONFIG = [
+      {
+          'OAUTH2_NAME': 'google',
+          'OAUTH2_DISPLAY_NAME': 'Google',
+          'OAUTH2_CLIENT_ID': 'client_id',
+          'OAUTH2_CLIENT_SECRET': 'client_secret',
+          'OAUTH2_TOKEN_URL': 'https://oauth2.googleapis.com/token',
+          'OAUTH2_AUTHORIZATION_URL': 'https://accounts.google.com/o/oauth2/v2/auth',
+          'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/auth/',
+          'OAUTH2_USERINFO_ENDPOINT': 'userinfo',
+          'OAUTH2_ICON': 'fa-google',
+          'OAUTH2_BUTTON_COLOR': '#0000ff',
+      },
+      {
+          'OAUTH2_NAME': 'github',
+          'OAUTH2_DISPLAY_NAME': 'Github',
+          'OAUTH2_CLIENT_ID': '[your_client_id]',
+          'OAUTH2_CLIENT_SECRET': '[your_client_secret]',
+          'OAUTH2_TOKEN_URL': 'https://github.com/login/oauth/access_token',
+          'OAUTH2_AUTHORIZATION_URL': 'https://github.com/login/oauth/authorize',
+          'OAUTH2_API_BASE_URL': 'https://api.github.com/',
+          'OAUTH2_USERINFO_ENDPOINT': 'user',
+          'OAUTH2_ICON': 'fa-github',
+          'OAUTH2_BUTTON_COLOR': '#0000ff',
+      }
+    ]


### PR DESCRIPTION
#### What this PR does / why we need it:

From pgadmin 5.5 there is OAUTH2 configuration available so it would be cool if there is an example for that part. I set it up like this, so that there is no need to adjust chart templates for now.

It also works if these vars are set in `variables` section of values.yaml with adding prefix PGADMIN_CONFIG_ to those vars.

~~Also...still having issues with google auth, something with OAUTH2_API_BASE_URL so work in progress, but here it is and if it helps someone great!~~

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
