### PR TITLE
pass .Values.serverDefinitions.servers as map instead of str

### DIFF
--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -61,7 +61,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serviceAccount.name` | The name of the service account. Otherwise uses the fullname. | `` |
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
 | `serverDefinitions.enabled` | Enables Server Definitions | `false` |
-| `serverDefinitions.servers` | Pre-configured server parameters | `` |
+| `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -64,9 +64,7 @@ Defines a JSON file containing server definitions. This allows connection inform
 */}}
 {{- define "pgadmin.serverDefinitions" -}}
 {
-  "Servers": {
-{{ .Values.serverDefinitions.servers | indent 4 }}
-  }
+  "Servers": {{ .Values.serverDefinitions.servers | toJson }}
 }
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
In our case, we need to generate dynamically the server list, and to have it as str is not ideal.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
