### PR TITLE
[pgadmin4] Add support for ingressClassName to ingress resource

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.9.0
+version: 1.9.1
 appVersion: 6.3
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.9.1
+version: 1.9.2
 appVersion: 6.3
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -65,6 +65,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.ingressClassName` | Ingress class name | `""` |
 | `ingress.hosts.host` | Ingress accepted hostname | `nil` |
 | `ingress.hosts.paths` | Ingress paths list | `[]` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.ingressClassName (semverCompare ">=1.18-0" $kubeVersion) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -81,6 +81,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  ingressClassName: ""
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -81,7 +81,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  ingressClassName: ""
+  # ingressClassName: ""
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
#### What this PR does / why we need it:
Since Kubernetes 1.18 ([source](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/)) it is possbile to specify a `ingressClassName` on ingress resources, to specify which `IngressClass` should be used to handle the ingress. This allows for the Chart to generate an ingress resource for a specified `IngressClass`.

#### Which issue this PR fixes
*None*

#### Special notes for your reviewer:
*None*

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
