### PR TITLE
serverDefinitions servers mapped instead of string

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.8.4
+version: 1.9.0
 appVersion: 6.3
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -61,7 +61,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serviceAccount.name` | The name of the service account. Otherwise uses the fullname. | `` |
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
 | `serverDefinitions.enabled` | Enables Server Definitions | `false` |
-| `serverDefinitions.servers` | Pre-configured server parameters | `` |
+| `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -63,9 +63,7 @@ Defines a JSON file containing server definitions. This allows connection inform
 */}}
 {{- define "pgadmin.serverDefinitions" -}}
 {
-  "Servers": {
-{{ .Values.serverDefinitions.servers | indent 4 }}
-  }
+  "Servers": {{ .Values.serverDefinitions.servers | toJson }}
 }
 {{- end -}}
 

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -61,16 +61,15 @@ serverDefinitions:
   ##
   enabled: false
 
-  servers: |-
-  #  "1": {
-  #    "Name": "Minimally Defined Server",
-  #    "Group": "Servers",
-  #    "Port": 5432,
-  #    "Username": "postgres",
-  #    "Host": "localhost",
-  #    "SSLMode": "prefer",
-  #    "MaintenanceDB": "postgres"
-  #  }
+  servers:
+  #  firstServer:
+  #    Name: "Minimally Defined Server"
+  #    Group: "Servers"
+  #    Port: 5432
+  #    Username: "postgres"
+  #    Host: "localhost"
+  #    SSLMode: "prefer"
+  #    MainteanceDB: "postgres"
 
 networkPolicy:
   enabled: true


### PR DESCRIPTION
Previously the values.yaml file had to contain the serverDefinitions as
followed:

```
serverDefinitions:
  servers: |-
    "1": {
      "Name": "Minimally Defined Server",
      "Group": "Servers",
      ...
    }
```

With this change, the following data structure is used:

```
serverDefinitions:
  servers:
    firstServer:
      Name: "Minimally Defined Server"
      Group: "Servers"
      ...
```

Be aware that this can break your current release, if upgrading to this
helm chart version 1.9.0.

This solution was brought to my attention by https://github.com/itscaro,
so thanks!

Signed-off-by: Rowan Ruseler <rowanruseler@gmail.com>
