### PR TITLE
[pgadmin4] Ability to override container's default entrypoint

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.9.4
+version: 1.9.5
 appVersion: 6.4
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -50,7 +50,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `image.tag` | Docker image tag | `""` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `annotations` | Deployment Annotations | `{}` |
-| `command` | Deployment command override | [["/entrypoint.sh"]](https://github.com/postgres/pgadmin4/blob/master/Dockerfile#L206) |
+| `command` | Deployment command override | `""` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.annotations` | Service Annotations | `{}` |
 | `service.port` | Service port | `80` |

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -50,6 +50,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `image.tag` | Docker image tag | `""` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `annotations` | Deployment Annotations | `{}` |
+| `command` | Deployment command override | [["/entrypoint.sh"]](https://github.com/postgres/pgadmin4/blob/master/Dockerfile#L206) |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.annotations` | Service Annotations | `{}` |
 | `service.port` | Service port | `80` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.command }}
+          command: {{ .Values.command }}
+        {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -16,7 +16,7 @@ annotations: {}
 
 ## Deployment entrypoint override
 ## Useful when there's a requirement to modify container's default entrypoint
-## For example: https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
+## Example ref: https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
 ## command: "['/bin/sh', '-c', 'source /vault/secrets/config && <entrypoint script>']"
 
 service:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -14,6 +14,11 @@ image:
 ## Deployment annotations
 annotations: {}
 
+## Deployment entrypoint override
+## Useful when there's a requirement to modify container's default entrypoint
+## For example: https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
+## command: "['/bin/sh', '-c', 'source /vault/secrets/config && <entrypoint script>']"
+
 service:
   type: ClusterIP
   port: 80
@@ -69,7 +74,7 @@ serverDefinitions:
   #    Username: "postgres"
   #    Host: "localhost"
   #    SSLMode: "prefer"
-  #    MainteanceDB: "postgres"
+  #    MaintenanceDB: "postgres"
 
 networkPolicy:
   enabled: true

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -15,9 +15,10 @@ image:
 annotations: {}
 
 ## Deployment entrypoint override
-## Useful when there's a requirement to modify container's default entrypoint
-## Example ref: https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
-## command: "['/bin/sh', '-c', 'source /vault/secrets/config && <entrypoint script>']"
+## Useful when there's a requirement to modify container's default:
+## https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
+## ref: https://github.com/postgres/pgadmin4/blob/master/Dockerfile#L206
+# command: "['/bin/sh', '-c', 'source /vault/secrets/config && <entrypoint script>']"
 
 service:
   type: ClusterIP


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the ability to override container's default entrypoint.
Specifically useful when there's a need to source external environment variables but may also assist with different approaches people find useful.

#### Which issue this PR fixes
  - fixes #135 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
