### PR TITLE
[pgadmin4] Add EnvFrom Option to Deployment

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.10.0
+version: 1.11.0
 appVersion: 6.10
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -81,6 +81,8 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `env.pgpassfile` | Path to pgpasssfile (optional). Needed chart reinstall for apply changes | `` |
 | `env.enhanced_cookie_protection` | Allows pgAdmin4 to create session cookies based on IP address | `"False"` |
 | `env.contextPath` | Context path for accessing pgadmin (optional) | `` |
+| `envVarsFromConfigMaps` | Array of ConfigMap names to load as environment variables | `[]` |
+| `envVarsFromSecrets` | Array of Secret names to load as environment variables | `[]` |
 | `persistentVolume.enabled` | If true, pgAdmin4 will create a Persistent Volume Claim | `true` |
 | `persistentVolume.accessMode` | Persistent Volume access Mode | `ReadWriteOnce` |
 | `persistentVolume.size` | Persistent Volume size | `10Gi` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -127,6 +127,17 @@ spec:
             - name: {{ .name | quote }}
               value: {{ .value | quote }}
           {{- end }}
+          {{- if or .Values.envVarsFromConfigMaps .Values.envVarsFromSecrets }}
+          envFrom:
+            {{- range .Values.envVarsFromConfigMaps }}
+            - configMapRef:
+                name: {{ . | quote }}
+            {{- end }}
+            {{- range .Values.envVarsFromSecrets }}
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - name: pgadmin-data
               mountPath: /var/lib/pgadmin

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -169,6 +169,16 @@ env:
   # - name: PGADMIN_LISTEN_PORT
   #   value: "8080"
 
+## Additional environment variables from ConfigMaps
+envVarsFromConfigMaps: []
+  # - array-of
+  # - config-map-names
+
+## Additional environment variables from Secrets
+envVarsFromSecrets: []
+  # - array-of
+  # - secret-names
+
 persistentVolume:
   ## If true, pgAdmin4 will create/use a Persistent Volume Claim
   ## If false, use emptyDir


### PR DESCRIPTION
#### What this PR does / why we need it:
Allows additional environment variables to be added to the pod using ConfigMaps or Secrets.  This is helpful when configuring Oauth2 (client id/secret) or other sensitive environment variables.

#### Which issue this PR fixes
n/a

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
