### PR TITLE
[pgadmin4] add "app.kubernetes.io/instance" label

### DIFF
--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 */}}
 {{- define "pgadmin.labels" -}}
 app.kubernetes.io/name: {{ include "pgadmin.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 helm.sh/chart: {{ include "pgadmin.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

By adding the "app.kubernetes.io/instance" label the pod (and deployment) can be selected by the name used when deploying the chart. This allows a user to execute a command like the below.

    kubectl get pods --namespace default -l "app.kubernetes.io/instance=whatever-name-I-choose-for-my-release"

My personal use case is that I have another application which uses a Postgresql database and I allow my users to dynamically deploy the pgadmin chart. However without the above label it's difficult to destroy/scale/etc. the chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
