### PR TITLE
[pgadmin4] Allow Raw varEnv usefull for vault csi var env and correct ex oauth2 

### DIFF
--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -20,7 +20,7 @@ extraSecretMounts:
 # To setup Github OAUTH
 ## https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
 # redirect|callback URI to set:
-## https://pgadmin4.example.com/oauth2/authorize 
+## https://pgadmin4.example.com/oauth2/authorize
 ---
 kind: Secret
 apiVersion: v1
@@ -40,7 +40,7 @@ stringData:
           'OAUTH2_CLIENT_SECRET': '[your_client_secret]',
           'OAUTH2_TOKEN_URL': 'https://www.googleapis.com/oauth2/v3/token',
           'OAUTH2_AUTHORIZATION_URL': 'https://accounts.google.com/o/oauth2/v2/auth',
-          'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/oauth2/v3/'
+          'OAUTH2_API_BASE_URL': 'https://www.googleapis.com/oauth2/v3/',
           'OAUTH2_USERINFO_ENDPOINT': 'userinfo',
           'OAUTH2_ICON': 'fa-google',
           'OAUTH2_BUTTON_COLOR': '#0000ff',

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -98,6 +98,9 @@ spec:
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
           env:
+          {{- if .Values.env.variablesRaw }}
+            {{- .Values.env.variablesRaw | toYaml | nindent 12 }}
+          {{- end }}
             - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
               value: {{ .Values.env.enhanced_cookie_protection | quote }}
             - name: PGADMIN_DEFAULT_EMAIL
@@ -126,9 +129,6 @@ spec:
           {{- range .Values.env.variables }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}
-          {{- end }}
-          {{- if .Values.env.variablesRaw }}
-            {{- .Values.env.variablesRaw | toYaml | nindent 12 }}
           {{- end }}
           {{- if or .Values.envVarsFromConfigMaps .Values.envVarsFromSecrets }}
           envFrom:

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
             - name: {{ .name | quote }}
               value: {{ .value | quote }}
           {{- end }}
+          {{- if .Values.env.variablesRaw }}
+            {{- .Values.env.variablesRaw | toYaml | nindent 12 }}
+          {{- end }}
           {{- if or .Values.envVarsFromConfigMaps .Values.envVarsFromSecrets }}
           envFrom:
             {{- range .Values.envVarsFromConfigMaps }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -169,6 +169,17 @@ env:
   # - name: PGADMIN_LISTEN_PORT
   #   value: "8080"
 
+  ## Add custom environment variables that will be injected to deployment
+  ## Add variable with all key value, Useful for csi
+  ## Ref: https://www.vaultproject.io/docs/platform/k8s/csi/examples
+  ##
+  variablesRaw: []
+  # - name: MY_VAR
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: MY_VAULT_CONFIG
+  #       key: MY_VAULT_KEY
+  
 ## Additional environment variables from ConfigMaps
 envVarsFromConfigMaps: []
   # - array-of


### PR DESCRIPTION
…exemple

#### What this PR does / why we need it:

- Accept env var with all tag/key, allow tu use vault csi injected var

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
