### PR TITLE
[pgadmin4] you can choose secret key now

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore markdown:
+*.md

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.11.0
+version: 1.12.0
 appVersion: "6.10"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -75,6 +75,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `extraSecretMounts` | Additional secret volume mounts for pgadmin4 pod | `[]` |
 | `extraContainers` | Sidecar containers to add to the pgadmin4 pod  | `"[]"` |
 | `existingSecret` | The name of an existing secret containing the pgadmin4 default password. | `""` |
+| `secretKeys.pgadminPasswordKey` | Name of key in existing secret to use for default pgadmin credentials. Only used when `existingSecret` is set. | `"PGADMIN_DEFAULT_PASSWORD"` |
 | `extraInitContainers` | Sidecar init containers to add to the pgadmin4 pod  | `"[]"` |
 | `env.email` | pgAdmin4 default email. Needed chart reinstall for apply changes | `chart@example.local` |
 | `env.password` | pgAdmin4 default password. Needed chart reinstall for apply changes | `SuperSecret` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -111,10 +111,11 @@ spec:
                 secretKeyRef:
           {{- if not .Values.existingSecret }}
                   name: {{ $fullName }}
+                  key: password
           {{- else }}
                   name: {{ .Values.existingSecret }}
-          {{- end }}
-                  key: password
+                  key: {{ .Values.secretKeys.pgadminPasswordKey }}
+          {{- end }}                  
           {{- if .Values.env.contextPath }}
             - name: SCRIPT_NAME
               value: {{ .Values.env.contextPath }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
           {{- else }}
                   name: {{ .Values.existingSecret }}
                   key: {{ .Values.secretKeys.pgadminPasswordKey }}
-          {{- end }}                  
+          {{- end }}
           {{- if .Values.env.contextPath }}
             - name: SCRIPT_NAME
               value: {{ .Values.env.contextPath }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -139,9 +139,13 @@ extraContainers: |
 #     - name: proxy-web
 #       containerPort: 4181
 
-## Provide the name for an existing secret.
-## Useful to avoid specifying password and server config in YAML files
+## @param existingSecret Name of existing secret to use for default pgadmin credentials. `env.password` will be ignored and picked up from this secret.
+##
 existingSecret: ""
+## @param secretKeys.pgadminPasswordKey Name of key in existing secret to use for default pgadmin credentials. Only used when `existingSecret` is set.
+##
+secretKeys:
+  pgadminPasswordKey: PGADMIN_DEFAULT_PASSWORD
 
 ## pgAdmin4 startup configuration
 ## Values in here get injected as environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
you can choose secret key now

#### Special notes for your reviewer:
Some users might have already created secrets with different key for pgadmin default password. For example official pgadmin4 docker image comes with key PGADMIN_DEFAULT_PASSWORD. Now we can pick a key name for password in our secret file instead of sticking to hardcoded 'password' key name.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
