### PR TITLE
[pgadmin4] added startupprobe to deployment

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.13.5
+version: 1.13.6
 appVersion: "6.15"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -94,6 +94,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `securityContext` | Custom [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pgAdmin4 pod | `` |
 | `containerSecurityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pgAdmin4 container | `` |
 | `livenessProbe` | [liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
+| `startupProbe` | [startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `readinessProbe` | [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `VolumePermissions.enabled` | Enables init container that changes volume permissions in the data directory  | `false` |
 | `extraInitContainers` | Init containers to launch alongside the app | `[]` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -89,6 +89,17 @@ spec:
               {{- end }}
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
+        {{- if .Values.startupProbe }}
+          startupProbe:
+            httpGet:
+              port: http
+              {{- if .Values.env.contextPath }}
+              path: "{{ .Values.env.contextPath }}/misc/ping"
+              {{- else }}
+              path: /misc/ping
+              {{- end }}
+            {{- .Values.startupProbe | toYaml | nindent 12 }}
+        {{- end }}
         {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:


### PR DESCRIPTION
#### What this PR does / why we need it:
I need to add a startupProbe in my implementation because my deployment need too much time to inject all the configurations

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x ] Chart Version bumped
- [x ] Variables are documented in the README.md
- [x ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
