### PR TITLE
[pgadmin4] fix: resource definition of test container

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.13.6
+version: 1.13.7
 appVersion: "6.15"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -330,12 +330,12 @@ test:
     tag: latest
   ## Resources request/limit for test-connection Pod
   resources: {}
-#     limits:
-#       cpu: 25m
-#       memory: 16Mi
-#     requests:
-#       cpu: 50m
-#       memory: 32Mi
+    # limits:
+    #   cpu: 50m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 25m
+    #   memory: 16Mi
   ## Security context for test-connection Pod
   securityContext:
     runAsUser: 5051


### PR DESCRIPTION
#### What this PR does / why we need it:
When using the chart and uncommenting the resource part of test container the chart deployment will fail.
Reason is that requests > limits
With this fix it is possible to just uncomment the resource part because request < limits

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
Thanks for this awesome chart! 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
