### PR TITLE
[pgadmin4] fix(ingress): make template resolution available for ingress secret name

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.13.10
+version: 1.13.11
 appVersion: "6.18"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -27,14 +27,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ tpl (.) $ | quote }}
       {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ tpl (.secretName) $ }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl (.host) $ | quote }}
       http:
         paths:
         {{- range .paths }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix the case when `ingress.tls.secretName`, `ingress.tls.host` or `ingress.hosts` are a templated value (similar to this issue https://github.com/bitnami/charts/issues/13503).

#### Checklist

- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
