### PR TITLE
[pgadmin4] Add namespace to all resources

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.15.1
+version: 1.15.2
 appVersion: "7.0"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -110,6 +110,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `podAnnotations` | Annotations for pod | `{}` |
 | `podLabels` | Labels for pod | `{}` |
+| `namespace` | Namespace where to deploy | `null` |
 | `init.resources` | Init container CPU/memory resource requests/limits | `{}` |
 | `test.image.registry` | Docker image registry for test | `docker.io` |
 | `test.image.repository` | Docker image for test | `busybox` |

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -101,3 +101,10 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Create the name of the namespace
+*/}}
+{{- define "pgadmin.namespaceName" -}}
+{{- default .Release.Namespace .Values.namespace }}
+{{- end }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 {{- if .Values.annotations }}

--- a/charts/pgadmin4/templates/hpa.yaml
+++ b/charts/pgadmin4/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "pgadmin.fullname" . }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 spec:

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -12,6 +12,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/pgadmin4/templates/networkpolicy.yaml
+++ b/charts/pgadmin4/templates/networkpolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ template "networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 spec:

--- a/charts/pgadmin4/templates/pvc.yaml
+++ b/charts/pgadmin4/templates/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
   {{- if .Values.persistentVolume.annotations }}

--- a/charts/pgadmin4/templates/secrets.yaml
+++ b/charts/pgadmin4/templates/secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $fullName }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/pgadmin4/templates/service.yaml
+++ b/charts/pgadmin4/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pgadmin.fullname" . }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}

--- a/charts/pgadmin4/templates/serviceaccount.yaml
+++ b/charts/pgadmin4/templates/serviceaccount.yaml
@@ -9,5 +9,5 @@ metadata:
   annotations:
     {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "pgadmin.namespaceName" . }}
 {{- end }}

--- a/charts/pgadmin4/templates/tests/test-connection.yaml
+++ b/charts/pgadmin4/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "pgadmin.fullname" . }}-test-connection"
+  namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
 {{ include "pgadmin.labels" . | indent 4 }}
   annotations:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -320,6 +320,10 @@ podLabels: {}
   # key1: value1
   # key2: value2
 
+# -- The name of the Namespace to deploy
+# If not set, `.Release.Namespace` is used
+namespace: null
+
 init:
   ## Init container resources
   ##


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `namespace` to all Helm chart resources, which is meant to allow `helm template` to show namespace in the resources as well. The absence of which can cause some test tools, for example, kyverno-cli to fail due to missing namespace, which is a part of its best practice policies. This namespace adding structure was inspired from how promtail does it.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
