### PR TITLE
[pgadmin4] Decouple serverDefinitions from existingSecret

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.16.1
+version: 1.17.0
 appVersion: "7.5"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -65,6 +65,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serviceAccount.name` | The name of the service account. Otherwise uses the fullname. | `` |
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
 | `serverDefinitions.enabled` | Enables Server Definitions | `false` |
+| `serverDefinitions.resourceType` | The type of resource to deploy server definitions (either `ConfigMap` or `Secret`) | `ConfigMap` |
 | `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |

--- a/charts/pgadmin4/templates/auth-secret.yaml
+++ b/charts/pgadmin4/templates/auth-secret.yaml
@@ -11,16 +11,3 @@ type: Opaque
 data:
   password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}
 {{- end }}
-{{- if .Values.serverDefinitions.enabled }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ $fullName }}-server-definitions
-  namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
-type: Opaque
-data:
-  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
-{{- end }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- .Values.podAnnotations | toYaml | nindent 8 }}
       {{- end }}
       {{- if not .Values.existingSecret }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/auth-secret.yaml") . | sha256sum }}
       {{- end }}
     {{- end }}
 
@@ -212,8 +212,13 @@ spec:
       {{- end }}
       {{- if .Values.serverDefinitions.enabled }}
         - name: definitions
+          {{- if eq .Values.serverDefinitions.resourceType "Secret" }}
           secret:
-            secretName: {{ template "pgadmin.secretName" . }}-server-definitions
+            secretName: {{ $fullName }}-server-definitions
+          {{- else }}
+          configMap:
+            name: {{ $fullName }}-server-definitions
+          {{- end }}
             items:
             - key: servers.json
               path: servers.json

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -213,7 +213,7 @@ spec:
       {{- if .Values.serverDefinitions.enabled }}
         - name: definitions
           secret:
-            secretName: {{ template "pgadmin.secretName" . }}
+            secretName: {{ template "pgadmin.secretName" . }}-server-definitions
             items:
             - key: servers.json
               path: servers.json

--- a/charts/pgadmin4/templates/secrets.yaml
+++ b/charts/pgadmin4/templates/secrets.yaml
@@ -10,7 +10,17 @@ metadata:
 type: Opaque
 data:
   password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}
-{{- if .Values.serverDefinitions.enabled }}
-  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
 {{- end }}
+{{- if .Values.serverDefinitions.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullName }}-server-definitions
+  namespace: {{ include "pgadmin.namespaceName" . }}
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
+type: Opaque
+data:
+  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
 {{- end }}

--- a/charts/pgadmin4/templates/server-definitions-configmap.yaml
+++ b/charts/pgadmin4/templates/server-definitions-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serverDefinitions.enabled ( ne .Values.serverDefinitions.resourceType "Secret" ) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pgadmin.fullname" . }}-server-definitions
+  namespace: {{ include "pgadmin.namespaceName" . }}
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
+data:
+  servers.json: |-
+{{ include "pgadmin.serverDefinitions" . | indent 4 }}
+{{- end }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.serverDefinitions.enabled ( eq .Values.serverDefinitions.resourceType "Secret" ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pgadmin.fullname" . }}-server-definitions
+  namespace: {{ include "pgadmin.namespaceName" . }}
+  labels:
+    {{- include "pgadmin.labels" . | nindent 4 }}
+type: Opaque
+data:
+  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
+{{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -72,6 +72,10 @@ serverDefinitions:
   ##
   enabled: false
 
+  ## The resource type to use for deploying server definitions.
+  ## Can either be ConfigMap or Secret
+  resourceType: ConfigMap
+
   servers:
   #  firstServer:
   #    Name: "Minimally Defined Server"


### PR DESCRIPTION
#### What this PR does / why we need it:

Users might want to adapt `serverDefinitions` while still having the ability to pre-define a secret for the super user's password. This PR decouples the secret creation of `serverDefinitions` from the password's secret to keep them separate.

In addition, users can specify `serverDefinitions.resourceType` to deploy the configuration as either `ConfigMap` (default) or `Secret`.

#### Which issue this PR fixes
  - fixes #182 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
