### PR TITLE
[pgadmin4] Adding labels and matchLabels to deployment file

### DIFF
--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
+    {{- with .Values.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- if .Values.annotations }}
   annotations:
   {{- if .Values.annotations }}
@@ -17,6 +20,9 @@ spec:
   selector:
     matchLabels:
       {{- include "pgadmin.selectorLabels" . | nindent 6 }}
+      {{- with .Values.matchLabels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- if .Values.strategy }}
   strategy:
     {{- .Values.strategy | toYaml | nindent 4 }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -314,6 +314,15 @@ affinity: {}
 ##
 podAnnotations: {}
 
+## Deployment labels
+##
+labels: {}
+
+## Deployment matchLabels
+##
+matchLabels: {}
+
+
 ## Pod labels
 ##
 podLabels: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding labels and matchLabels to deployment file so it could be added custom labels to deployment for finding it and scale up or down depending of the label. Better for filtering and group deployment files

#### Special notes for your reviewer:
Trying to make a kubernetes cronjob that scale down pods depending of the label of their deployment file and there is no possibility to add them on demand.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
