### PR TITLE
[pgadmin4] Opt out of API credential automounting

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.17.3
+version: 1.18.0
 appVersion: "7.6"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -63,6 +63,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serviceAccount.create` | Creates a ServiceAccount for the pod. | `false` |
 | `serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
 | `serviceAccount.name` | The name of the service account. Otherwise uses the fullname. | `` |
+| `serviceAccount.automountServiceAccountToken` | Opt out of API credential automounting. | `false` |
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
 | `serverDefinitions.enabled` | Enables Server Definitions | `false` |
 | `serverDefinitions.resourceType` | The type of resource to deploy server definitions (either `ConfigMap` or `Secret`) | `ConfigMap` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
     {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ default $fullName .Values.serviceAccount.name }}
     {{- end }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
     {{- if or (.Values.VolumePermissions.enabled) .Values.extraInitContainers }}
       initContainers:
       {{- if .Values.VolumePermissions.enabled }}

--- a/charts/pgadmin4/templates/serviceaccount.yaml
+++ b/charts/pgadmin4/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
     {{- .Values.serviceAccount.annotations | toYaml | nindent 4 }}
   {{- end }}
   namespace: {{ include "pgadmin.namespaceName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -53,6 +53,10 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Opt out of API credential automounting.
+  # If you don't want the kubelet to automatically mount a ServiceAccount's API credentials,
+  # you can opt out of the default behavior
+  automountServiceAccountToken: false
 
 ## Strategy used to replace old Pods by new ones
 ## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR makes ServiceAccount's API credentials [automounting configurable](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#opt-out-of-api-credential-automounting) and disabled by default.
It is considered to be a common best practice and actually a demand of Kubernetes CIS framework, for example look at CIS ID 5.1.6 [here](https://learn.microsoft.com/en-us/azure/aks/cis-kubernetes).
Also, there were some lengthy discussions within K8s community to make this default (disabled) setting in the distribution, but maintainers declined it as break of backward compatibility, leaving it for responsibility of an administrator.
More details in this GH [issue](https://github.com/kubernetes/kubernetes/issues/57601) and StackOverflow [question](https://stackoverflow.com/questions/67986547/why-the-pods-in-kubernetes-are-automounting-the-service-accounts-secret).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
