### PR TITLE
[pgadmin4] Set app version label to image tag

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.18.0
+version: 1.18.1
 appVersion: "7.6"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -35,12 +35,10 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "pgadmin.labels" -}}
-app.kubernetes.io/name: {{ include "pgadmin.name" . }}
-helm.sh/chart: {{ include "pgadmin.chart" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "pgadmin.name" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "pgadmin.chart" . }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR sets the `app.kubernetes.io/version` label to match real application version, which could be overridden by `image.tag` value.
Previously, the label did inherit only `appVersion` set in the chart metadata. Now if the image version (tag) is not set, the label will fallback to the app version defined by the chart.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
