### PR TITLE
[pgadmin4] Fix accidental volume override

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.18.2
+version: 1.18.3
 appVersion: "7.7"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -6,7 +6,8 @@
 # https://www.pgadmin.org/docs/pgadmin4/latest/oauth2.html
 
 extraConfigmapMounts:
-  - name: pgadmin4-config
+  - name: config-local
+    configMap: pgadmin4-config
     subPath: config_local.py
     mountPath: "/pgadmin4/config_local.py"
     readOnly: true

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -199,7 +199,7 @@ spec:
       {{- range .Values.extraConfigmapMounts }}
         - name: {{ .name }}
           configMap:
-            name: {{ .name }}
+            name: {{ .configMap }}
             defaultMode: {{ .defaultMode | default 256 }}
       {{- end }}
       {{- range .Values.extraSecretMounts }}


### PR DESCRIPTION
#### What this PR does / why we need it:
https://github.com/rowanruseler/helm-charts/pull/214 fixed incorrect OAuth2 example, however it produced two new unforeseen consequences:
1. The change is not backward compatible because if someone already had `extraConfigmapMounts` set they would need rename it (`config-local` -> `pgadmin4-config`) for the upgraded deployment to progress.
2. Example now actually uses `pgadmin4-config` as default volume name which could be pretty common to mount volumes for other configuration purposes. For example, me personally, I have used such name for a volume which stored `file.pgpass` file. So, in the end, I had to do some back and forth reconfiguration of my deployment in order to upgrade.

This PR brings back `config-local` as a volume name (which I think is more appropriate identicator for what this volume contains), and keeps https://github.com/rowanruseler/helm-charts/pull/214 fixed at the same time. It should bring a much smoother experience for anyone upgrading from 1.16.0 and earlier.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
