### PR TITLE
[pgadmin4] Add Microsoft OAuth example with OIDC support

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.19.0
-appVersion: "7.8"
+version: 1.20.0
+appVersion: "8.1"
 keywords:
   - pgadmin
   - postgres

--- a/charts/pgadmin4/examples/add-oauth2-config.yaml
+++ b/charts/pgadmin4/examples/add-oauth2-config.yaml
@@ -92,5 +92,22 @@ data:
         'OAUTH2_SCOPE': 'User.Read',
         'OAUTH2_ICON': 'fa-microsoft',
         'OAUTH2_BUTTON_COLOR': '#0000ff',
+      },
+      {
+        'OAUTH2_NAME': 'microsoft-oidc',
+        'OAUTH2_DISPLAY_NAME': 'Microsoft OIDC',
+        'OAUTH2_CLIENT_ID': os.environ['OAUTH2_CLIENT_ID'],
+        'OAUTH2_CLIENT_SECRET': os.environ['OAUTH2_CLIENT_SECRET'],
+        'OAUTH2_TOKEN_URL': 'https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/token',
+        'OAUTH2_AUTHORIZATION_URL': 'https://login.microsoftonline.com/{YOUR_TENANT_ID}/oauth2/v2.0/authorize',
+        'OAUTH2_SERVER_METADATA_URL': 'https://login.microsoftonline.com/{YOUR_TENANT_ID}/v2.0/.well-known/openid-configuration',
+        'OAUTH2_API_BASE_URL': 'https://graph.microsoft.com/v1.0/',
+        'OAUTH2_USERINFO_ENDPOINT': 'https://graph.microsoft.com/oidc/userinfo',
+        'OAUTH2_SCOPE': 'openid profile email',
+        'OAUTH2_ICON': 'fa-microsoft',
+        'OAUTH2_BUTTON_COLOR': '#0000ff',
+        'OAUTH2_ADDITIONAL_CLAIMS': {
+          'groups': ["{LIST_OF_YOUR_GROUP_GUIDS}"],
+        }
       }
     ]


### PR DESCRIPTION
#### What this PR does / why we need it:
OIDC allows to use server side claim filtering via information provided in the token. See https://learn.microsoft.com/en-us/security/zero-trust/develop/configure-tokens-group-claims-app-roles and pgAdmin documentation for more information.

This funcionality requires at least pgAdmin4 version 8.0.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
