### PR TITLE
[pgadmin4] improve pod annotations to be able to have more checksums

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.20.0
+version: 1.21.0
 appVersion: "8.1"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -112,6 +112,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `tolerations` | Node tolerations for pod assignment | `[]` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `podAnnotations` | Annotations for pod | `{}` |
+| `templatedPodAnnotations` | Templated annotations for pod | `{}` |
 | `podLabels` | Labels for pod | `{}` |
 | `namespace` | Namespace where to deploy resources | `null` |
 | `init.resources` | Init container CPU/memory resource requests/limits | `{}` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -29,13 +29,22 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-    {{- if or (not .Values.existingSecret) .Values.podAnnotations }}
+    {{- if or (not .Values.existingSecret) .Values.podAnnotations .Values.templatedPodAnnotations .Values.serverDefinitions.enabled }}
       annotations:
       {{- if .Values.podAnnotations }}
         {{- .Values.podAnnotations | toYaml | nindent 8 }}
       {{- end }}
+      {{- with .Values.templatedPodAnnotations }}
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
       {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/auth-secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if and .Values.serverDefinitions.enabled ( eq .Values.serverDefinitions.resourceType "Secret" ) }}
+        checksum/secret-server-definitions: {{ include (print $.Template.BasePath "/server-definitions-secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if and .Values.serverDefinitions.enabled ( ne .Values.serverDefinitions.resourceType "Secret" ) }}
+        checksum/config-server-definitions: {{ include (print $.Template.BasePath "/server-definitions-configmap.yaml") . | sha256sum }}
       {{- end }}
     {{- end }}
 

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -323,6 +323,10 @@ affinity: {}
 ## Pod annotations
 ##
 podAnnotations: {}
+templatedPodAnnotations: |-
+#   checksum/configmap-oauth2: {{ include "<parent-chart-name>/templates/configmap-oauth2.yaml" $ | sha256sum }}
+#   checksum/secret-oauth2: "{{ include "<parent-chart-name>/templates/secret-oauth2.yaml" $ | sha256sum }}"
+#   checksum/secret-pgpass: "{{ include "<parent-chart-name>/templates/secret-pgpass.yaml" $ | sha256sum }}"
 
 ## Pod labels
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

We use this chart as dependency (child chart) in our chart and create secrets and configmaps for oauth2 config and pgpass config. Currently if any of these config is changed, pod is not restarted automatically.

With this MR we can add templated checksum annotations to the pod. So for example we can use these annotations to re-deploy the pod automatically, when oauth2 config or pgpass secret is updated.

I also added checksum of `serverDefinitions` config.

#### Which issue this PR fixes

No issues was created.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
