### PR TITLE
[pgadmin4] make it possible to use  https in container

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.21.0
+version: 1.22.0
 appVersion: "8.1"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.22.0
+version: 1.23.0
 appVersion: "8.1"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -92,39 +92,48 @@ spec:
             {{- toYaml .Values.args | nindent 12 }}
         {{- end }}
           ports:
-            - name: http
+            - name: {{ .Values.service.portName }}
               containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
         {{- if .Values.livenessProbe }}
           livenessProbe:
             httpGet:
-              port: http
+              port: {{ .Values.service.portName }}
               {{- if .Values.env.contextPath }}
               path: "{{ .Values.env.contextPath }}/misc/ping"
               {{- else }}
               path: /misc/ping
+              {{- end }}
+              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
+              scheme: {{ upper .Values.service.portName }}
               {{- end }}
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.startupProbe }}
           startupProbe:
             httpGet:
-              port: http
+              port: {{ .Values.service.portName }}
               {{- if .Values.env.contextPath }}
               path: "{{ .Values.env.contextPath }}/misc/ping"
               {{- else }}
               path: /misc/ping
+              {{- end }}
+              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
+              scheme: {{ upper .Values.service.portName }}
               {{- end }}
             {{- .Values.startupProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:
-              port: http
+              port: {{ .Values.service.portName }}
               {{- if .Values.env.contextPath }}
               path: "{{ .Values.env.contextPath }}/misc/ping"
               {{- else }}
               path: /misc/ping
+              {{- end }}
+              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
+              scheme: {{ upper .Values.service.portName }}
               {{- end }}
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

With the current values it is possible to enable the https in pgadmin container and service. The only problem is that there is no way to configure scheme for probs. This MR make it possible. It also uses `.Values.service.portName ` in various places in deployment definition instead of using hardcoded "http", so it is in sync with service definition.

#### Which issue this PR fixes

No issues was created.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
