### PR TITLE
[pgadmin4] Add support for envVarsExtra

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.24.0-1
+version: 1.24.0
 appVersion: "8.4"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.23.4
+version: 1.24.0-1
 appVersion: "8.4"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -89,6 +89,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `env.contextPath` | Context path for accessing pgadmin (optional) | `` |
 | `envVarsFromConfigMaps` | Array of ConfigMap names to load as environment variables | `[]` |
 | `envVarsFromSecrets` | Array of Secret names to load as environment variables | `[]` |
+| `envVarsExtra` | Array of arbitrary environment variable definitions (e.g., for fetching from Kubernetes Secrets) | `[]` |
 | `persistentVolume.enabled` | If true, pgAdmin4 will create a Persistent Volume Claim | `true` |
 | `persistentVolume.accessMode` | Persistent Volume access Mode | `ReadWriteOnce` |
 | `persistentVolume.size` | Persistent Volume size | `10Gi` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -132,6 +132,9 @@ spec:
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
           env:
+          {{- with .Values.envVarsExtra }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
             - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
               value: {{ .Values.env.enhanced_cookie_protection | quote }}
             - name: PGADMIN_DEFAULT_EMAIL

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -198,6 +198,19 @@ envVarsFromSecrets: []
   # - array-of
   # - secret-names
 
+## Additional environment variables
+envVarsExtra: []
+  # - name: POSTGRES_USERNAME
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: pgadmin.pgadmin-db.credentials.postgresql.acid.zalan.do
+  #       key: username
+  # - name: POSTGRES_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: pgadmin.pgadmin-db.credentials.postgresql.acid.zalan.do
+  #       key: password
+
 persistentVolume:
   ## If true, pgAdmin4 will create/use a Persistent Volume Claim
   ## If false, use emptyDir


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR adds support for generic environment variables. This allows retrieving values from Kubernetes Secrets.

#### Which issue this PR fixes

N&A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
