### PR TITLE
[pgadmin4] Be able to define existingSecret or existingConfigmap containing serverDefinitions

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.24.1
+version: 1.25.0
 appVersion: "8.5"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -68,6 +68,8 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `strategy` | Specifies the strategy used to replace old Pods by new ones | `{}` |
 | `serverDefinitions.enabled` | Enables Server Definitions | `false` |
 | `serverDefinitions.resourceType` | The type of resource to deploy server definitions (either `ConfigMap` or `Secret`) | `ConfigMap` |
+| `serverDefinitions.existingConfigmap` | The name of a configMap containing Server Definitions. Only used when `serverDefinitions.resourceType` is `ConfigMap` | `""` |
+| `serverDefinitions.existingSecret` | The name of a Secret containing Server Definitions. Only used when `serverDefinitions.resourceType` is `Secret` | `""` |
 | `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |
@@ -79,7 +81,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `extraConfigmapMounts` | Additional configMap volume mounts for pgadmin4 pod | `[]` |
 | `extraSecretMounts` | Additional secret volume mounts for pgadmin4 pod | `[]` |
 | `extraContainers` | Sidecar containers to add to the pgadmin4 pod  | `"[]"` |
-| `existingSecret` | The name of an existing secret containing the pgadmin4 default password. | `""` |
+| `existingSecret` | The name of an existing secret containing the pgadmin4 default password and, optionally, Server Definitions. | `""` |
 | `secretKeys.pgadminPasswordKey` | Name of key in existing secret to use for default pgadmin credentials. Only used when `existingSecret` is set. | `"password"` |
 | `extraInitContainers` | Sidecar init containers to add to the pgadmin4 pod  | `"[]"` |
 | `env.email` | pgAdmin4 default email. Needed chart reinstall for apply changes | `chart@domain.com` |

--- a/charts/pgadmin4/templates/NOTES.txt
+++ b/charts/pgadmin4/templates/NOTES.txt
@@ -1,3 +1,7 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -19,3 +23,5 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}
+
+{{- include "pgadmin.validateValues" . }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/auth-secret.yaml") . | sha256sum }}
       {{- end }}
     {{- end }}
-
     spec:
     {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ default $fullName .Values.serviceAccount.name }}
@@ -157,9 +156,11 @@ spec:
             - name: SCRIPT_NAME
               value: {{ .Values.env.contextPath }}
           {{- end }}
-          {{- if .Values.serverDefinitions.enabled }}
+          {{- if and (.Values.serverDefinitions.enabled) (or (eq .Values.serverDefinitions.resourceType "ConfigMap") (eq .Values.serverDefinitions.resourceType "Secret")) -}}
+          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
             - name: PGADMIN_SERVER_JSON_FILE
               value: /pgadmin4/servers.json
+          {{- end }}
           {{- end }}
           {{- range .Values.env.variables }}
             - name: {{ .name | quote }}
@@ -180,10 +181,12 @@ spec:
             - name: pgadmin-data
               mountPath: /var/lib/pgadmin
               subPath: {{ .Values.persistentVolume.subPath | default "" }}
-          {{- if .Values.serverDefinitions.enabled }}
+          {{- if and (.Values.serverDefinitions.enabled) (or (eq .Values.serverDefinitions.resourceType "ConfigMap") (eq .Values.serverDefinitions.resourceType "Secret")) -}}
+          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
             - name: definitions
               mountPath: /pgadmin4/servers.json
               subPath: servers.json
+          {{- end }}
           {{- end }}
           {{- range .Values.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -228,18 +231,21 @@ spec:
       {{- if .Values.extraVolumes }}
         {{- .Values.extraVolumes | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.serverDefinitions.enabled }}
+      {{- if and (.Values.serverDefinitions.enabled) (eq .Values.serverDefinitions.resourceType "Secret") -}}
+        {{- if or (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
         - name: definitions
-          {{- if eq .Values.serverDefinitions.resourceType "Secret" }}
           secret:
-            secretName: {{ $fullName }}-server-definitions
-          {{- else }}
+            secretName: {{ include "pgadmin.serverDefinitionsSecret" . }}
+        {{- end }}
+      {{- else if and (.Values.serverDefinitions.enabled) (eq .Values.serverDefinitions.resourceType "ConfigMap") -}}
+        {{ if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.servers) }}
+        - name: definitions
           configMap:
-            name: {{ $fullName }}-server-definitions
-          {{- end }}
+            name: {{ include "pgadmin.serverDefinitionsConfigmap" . }}
             items:
             - key: servers.json
               path: servers.json
+        {{- end }}
       {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/pgadmin4/templates/server-definitions-configmap.yaml
+++ b/charts/pgadmin4/templates/server-definitions-configmap.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.serverDefinitions.enabled ( ne .Values.serverDefinitions.resourceType "Secret" ) }}
+{{- if not .Values.serverDefinitions.existingConfigmap -}}
+{{- if and (.Values.serverDefinitions.enabled) (eq .Values.serverDefinitions.resourceType "ConfigMap") (.Values.serverDefinitions.servers) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,4 +10,5 @@ metadata:
 data:
   servers.json: |-
 {{ include "pgadmin.serverDefinitions" . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -1,5 +1,5 @@
-{{- if not .Values.existingSecret }}
-{{- if and .Values.serverDefinitions.enabled ( eq .Values.serverDefinitions.resourceType "Secret" ) }}
+{{- if and (not .Values.serverDefinitions.existingSecret) (not .Values.existingSecret) -}}
+{{- if and (.Values.serverDefinitions.enabled) ( eq .Values.serverDefinitions.resourceType "Secret") (.Values.serverDefinitions.servers) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -85,6 +85,12 @@ serverDefinitions:
   ## Can either be ConfigMap or Secret
   resourceType: ConfigMap
 
+  # If resource type is set to ConfigMap, specify existingConfigmap containing definitions
+  existingConfigmap: ""
+
+  # If resource type is set to Secret, specify existingSecret containing definitions
+  existingSecret: ""
+
   servers:
   #  firstServer:
   #    Name: "Minimally Defined Server"


### PR DESCRIPTION
[pgadmin4] Be able to define existingSecret or existingConfigmap containing serverDefinitions

#### What this PR does / why we need it:
When providing the pgadmin credentials via `.existingSecret`, one is forced to also put server definitions in the exact same secret, if `.serverDefinitions.resourceType` is set to "Secret".
This PR allows users to define a separate secret containing server definitions or to define an external ConfigMap

#### Which issue this PR fixes
  - fixes #182
  - fixes #227

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
