### PR TITLE
[pgadmin4] fix bug where secret isnt created when using .serverDefinitions.resourceType

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.25.1
+version: 1.25.2
 appVersion: "8.5"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -130,10 +130,10 @@ Generate serverDefinitions secret name
 {{- if eq .Values.serverDefinitions.resourceType "Secret" -}}
     {{- if .Values.serverDefinitions.existingSecret }}
         {{- printf "%s" (.Values.serverDefinitions.existingSecret) }}
+    {{- else if .Values.serverDefinitions.servers }}
+        {{- include "pgadmin.fullname" . }}-server-definitions
     {{- else if .Values.existingSecret }}
         {{- printf "%s" (.Values.existingSecret) }}
-    {{- else }}
-        {{- include "pgadmin.fullname" . }}-server-definitions
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.serverDefinitions.existingSecret) (not .Values.existingSecret) -}}
+{{- if not .Values.serverDefinitions.existingSecret -}}
 {{- if and (.Values.serverDefinitions.enabled) ( eq .Values.serverDefinitions.resourceType "Secret") (.Values.serverDefinitions.servers) }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR is an addition to my previous one https://github.com/rowanruseler/helm-charts/pull/249.
It fixes a bug, where the Secret manifest for Server Definitions isn't created, when `.existingSecret` is definied - which is usally the case when credentials are defined in a Secret.
The combination of `.serverDefinitions.resourceType: Secret` and  `.serverDefinitions.servers: {firstServer: ...}` now creates the corresponding secret.

#### Special notes for your reviewer:
Main issue is the `(not .Values.existingSecret)` [here](https://github.com/rowanruseler/helm-charts/pull/249/commits/829d9f8dfd06654819bfa7cca98adbf3079e3ef1#diff-ad14e1d649548822bbe61b5c1355900ed997f8019c6d4dfbf5c857b828124ff6R1)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
