### PR TITLE
[pgadmin4] Removed image.tag from app.kubernetes.io/version

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.33.2
+version: 1.33.3
 appVersion: "8.13"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Common labels
 {{- define "pgadmin.labels" -}}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/name: {{ include "pgadmin.name" . }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "pgadmin.chart" . }}
 {{- with .Values.commonLabels }}
 {{ toYaml .  }}


### PR DESCRIPTION
Pinning the `image.tag` to a specific digest allows full control over what image is actually deployed. But at the moment this breaks the chart because a label must be no more than 63 characters.

This commit resolves:
* rowanruseler/helm-charts/issues/267
