### PR TITLE
[pgadmin4] allow setting revisionHistoryLimit

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.37.0
+version: 1.37.1
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.37.1
+version: 1.38.0
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -50,6 +50,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `image.tag` | Docker image tag | `""` |
 | `image.pullPolicy` | Docker image pull policy | `IfNotPresent` |
 | `annotations` | Deployment Annotations | `{}` |
+| `revisionHistoryLimit` | The number of old history to retain to allow rollback | `10` |
 | `commonLabels` | Add labels to all the deployed resources | `{}` |
 | `priorityClassName` | Deployment priorityClassName | `""` |
 | `command` | Deployment command override | `""` |

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "pgadmin.selectorLabels" . | nindent 6 }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -14,6 +14,9 @@ image:
 ## Deployment annotations
 annotations: {}
 
+## revisionHistoryLimit The number of old history to retain to allow rollback
+revisionHistoryLimit: 10
+
 ## commonLabels Add labels to all the deployed resources
 commonLabels: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This allows setting revisionHistoryLimit
Default value is set to 10, which already is the default kubernetes value.
That way we make this change a non-breaking change.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
