### PR TITLE
[pgadmin4] Dynamic tpl the server-definitions + toPrettyJson

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.38.0
+version: 1.37.1
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.37.0
+version: 1.38.0
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -72,6 +72,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serverDefinitions.resourceType` | The type of resource to deploy server definitions (either `ConfigMap` or `Secret`) | `ConfigMap` |
 | `serverDefinitions.existingConfigmap` | The name of a configMap containing Server Definitions. Only used when `serverDefinitions.resourceType` is `ConfigMap` | `""` |
 | `serverDefinitions.existingSecret` | The name of a Secret containing Server Definitions. Only used when `serverDefinitions.resourceType` is `Secret` | `""` |
+| `serverDefinitions.useStringData` | The Secret will template using plainText stringData instead of data | `false` |
 | `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -72,7 +72,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `serverDefinitions.resourceType` | The type of resource to deploy server definitions (either `ConfigMap` or `Secret`) | `ConfigMap` |
 | `serverDefinitions.existingConfigmap` | The name of a configMap containing Server Definitions. Only used when `serverDefinitions.resourceType` is `ConfigMap` | `""` |
 | `serverDefinitions.existingSecret` | The name of a Secret containing Server Definitions. Only used when `serverDefinitions.resourceType` is `Secret` | `""` |
-| `serverDefinitions.useStringData` | The Secret will template using plainText stringData instead of data | `false` |
+| `serverDefinitions.useStringData` | The Secret will template using plainText stringData instead of base64 data | `false` |
 | `serverDefinitions.servers` | Pre-configured server parameters | `{}` |
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -63,9 +63,7 @@ Generate chart secret name
 Defines a JSON file containing server definitions. This allows connection information to be pre-loaded into the instance of pgAdmin in the container. Note that server definitions are only loaded on first launch, i.e. when the configuration database is created, and not on subsequent launches using the same configuration database.
 */}}
 {{- define "pgadmin.serverDefinitions" -}}
-{
-  "Servers": {{ .Values.serverDefinitions.servers | toJson }}
-}
+{{ tpl ( dict "Servers" .Values.serverDefinitions.servers | toPrettyJson) . }}
 {{- end -}}
 
 {{/*

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -63,7 +63,7 @@ Generate chart secret name
 Defines a JSON file containing server definitions. This allows connection information to be pre-loaded into the instance of pgAdmin in the container. Note that server definitions are only loaded on first launch, i.e. when the configuration database is created, and not on subsequent launches using the same configuration database.
 */}}
 {{- define "pgadmin.serverDefinitions" -}}
-{{ tpl ( dict "Servers" .Values.serverDefinitions.servers | toPrettyJson) . }}
+{{ tpl (dict "Servers" .Values.serverDefinitions.servers | toPrettyJson) . }}
 {{- end -}}
 
 {{/*

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -8,7 +8,8 @@ metadata:
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
-data:
-  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
+stringData:
+  servers.json:
+{{ include "pgadmin.serverDefinitions" . | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -8,8 +8,13 @@ metadata:
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
+{{- if .Values.serverDefinitions.useStringData }}
 stringData:
-  servers.json:
-{{ include "pgadmin.serverDefinitions" . | indent 4 }}
+  servers.json: |
+    {{- include "pgadmin.serverDefinitions" . | nindent 4 }}
+{{- else }}
+data:
+  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -102,6 +102,9 @@ serverDefinitions:
   # If resource type is set to Secret, specify existingSecret containing definitions
   existingSecret: ""
 
+  # If resource type is set to Secret, use stringData instead of data
+  useStringData: false
+
   servers:
   #  firstServer:
   #    Name: "Minimally Defined Server"


### PR DESCRIPTION
Moved to toPrettyJson function for clean code and more understandable configMap/secret

Moved to dict instead of creating json manually

And the important thing is that added tpl function to the whole json which is needed to dynamically provision predefined serverDefinitions. Which needed in use cases of dynamic postgres configuration.

Added new boolean value serverDefinitions.useStringData that changes the template of the serverDefinitions secret to plainText stringData instead of base64 data