### PR TITLE
feat(pgadmin4): import servers with tpl/json & secret toggle, tidy docs

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.38.0
+version: 1.39.0
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -1,5 +1,4 @@
-{{- if not .Values.serverDefinitions.existingSecret -}}
-{{- if and (.Values.serverDefinitions.enabled) ( eq .Values.serverDefinitions.resourceType "Secret") (.Values.serverDefinitions.servers) }}
+{{- if and .Values.serverDefinitions.enabled (eq .Values.serverDefinitions.resourceType "Secret") .Values.serverDefinitions.servers (not .Values.serverDefinitions.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,7 +7,7 @@ metadata:
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
-data:
-  servers.json: {{ include "pgadmin.serverDefinitions" . | b64enc | quote }}
-{{- end }}
+{{- $servers := include "pgadmin.serverDefinitions" . }}
+{{- $block := ternary (printf "stringData:\n  servers.json: |-\n%s" ($servers | indent 4)) (printf "data:\n  servers.json: %s" ($servers | b64enc | quote)) .Values.serverDefinitions.useStringData }}
+{{ $block }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -81,34 +81,40 @@ strategy: {}
   #   maxSurge: 0
   #   maxUnavailable: 1
 
-## Server definitions will be loaded at launch time. This allows connection
-## information to be pre-loaded into the instance of pgAdmin4 in the container.
-## Note that server definitions are only loaded on first launch,
-## i.e. when the configuration database is created, and not on subsequent launches using the same configuration database.
-## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/import_export_servers.html
+## Pre-load pgAdmin4 with servers at first start-up.
+## Servers are imported only the first time the config DB is created.
+## Docs: https://www.pgadmin.org/docs/pgadmin4/latest/import_export_servers.html
 ##
 serverDefinitions:
-  ## If true, server definitions will be created
-  ##
+  # Enable/disable server import
   enabled: false
 
-  ## The resource type to use for deploying server definitions.
-  ## Can either be ConfigMap or Secret
+  # Storage for the server JSON:
+  #   ConfigMap - plain text (good for non-secret data)
+  #   Secret    - base-64 (better for credentials)
   resourceType: ConfigMap
 
-  # If resource type is set to ConfigMap, specify existingConfigmap containing definitions
+  # Use this only when `resourceType` = ConfigMap - point to an existing ConfigMap
+  # that already holds your `servers.json`
   existingConfigmap: ""
 
-  # If resource type is set to Secret, specify existingSecret containing definitions
+  # Use this only when `resourceType` = Secret - point to an existing Secret
+  # that already holds your `servers.json`.
   existingSecret: ""
 
+  # Set to true to put raw JSON under `stringData` (handy for dry-runs/debug).
+  # Leave false to keep the default base-64 in `data`.
+  useStringData: false
+
+  # Inline server definitions (ignore if you point to an existing resource)
+  # You can use Helm templates here, e.g. Host: "{{ .Values.example.host }}"
   servers:
   #  firstServer:
   #    Name: "Minimally Defined Server"
   #    Group: "Servers"
-  #    Port: 5432
   #    Username: "postgres"
-  #    Host: "localhost"
+  #    Host: "{{ .Values.example.host }}"
+  #    Port: {{ .Values.example.port }}
   #    SSLMode: "prefer"
   #    MaintenanceDB: "postgres"
 


### PR DESCRIPTION
Inspired by @KorenP1's work in PR #277

* Add `pgadmin.serverDefinitions` helper (tpl + toPrettyJson)
* Secret template: ternary switch between `data` (base64) and `stringData` blocks
* Robust value validation for `resourceType` and required fields
* Added `app.kubernetes.io/instance:` in common labels
* Rewrite `values.yaml` comments; add templating example in `servers`
