### PR TITLE
fix(pgadmin4): servers port example quoted

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.39.1
+version: 1.39.2
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -121,7 +121,6 @@ Usage:
     {{- end }}
 {{- end -}}
 
-
 {{/*
 Validation helpers.
 */}}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -114,7 +114,7 @@ serverDefinitions:
   #    Group: "Servers"
   #    Username: "postgres"
   #    Host: "{{ .Values.example.host }}"
-  #    Port: {{ .Values.example.port }}
+  #    Port: "{{ .Values.example.port }}"
   #    SSLMode: "prefer"
   #    MaintenanceDB: "postgres"
 


### PR DESCRIPTION
Because Helm feeds raw YAML to the YAML parser before it ever sees any Go-template syntax, we need to quote the port part. Else it results in:

```
Error: cannot load values.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.example.port":interface {}(nil)}
```

Values.yaml example:
```
serverDefinitions:
  enabled: true
  resourceType: Secret

  useStringData: true

  servers:
    firstServer:
      Name: "Minimally Defined Server"
      Group: "Servers"
      Username: "postgres"
      Host: "{{ .Values.example.host }}"
      Port: "{{ .Values.example.port }}"
      SSLMode: "prefer"
      MaintenanceDB: "postgres"

example:
  host: "localhost"
  port: 443
```

Output example:
```
# Source: pgadmin4/templates/server-definitions-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: pgadmin4-server-definitions
  namespace: "istio-system"
  labels:
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: pgadmin4
    app.kubernetes.io/name: pgadmin4
    app.kubernetes.io/version: "9.2"
    helm.sh/chart: pgadmin4-1.39.1
type: Opaque
stringData:
  servers.json: |-
    {
      "Servers": {
        "firstServer": {
          "Group": "Servers",
          "Host": "localhost",
          "MaintenanceDB": "postgres",
          "Name": "Minimally Defined Server",
          "Port": "443",
          "SSLMode": "prefer",
          "Username": "postgres"
        }
      }
    }
```
