### PR TITLE
fix(pgadmin4): correctly handle int and bool value in servers.json

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.39.1
+version: 1.39.2
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/examples/serverdefinitions.yaml
+++ b/charts/pgadmin4/examples/serverdefinitions.yaml
@@ -1,0 +1,79 @@
+#
+# values.yaml
+#
+example:
+  host: "localhost"
+  port: 443
+  shared: false
+  timeout: "60" # _helpers.tpl should convert this to an int
+  maintenancedb: postgres # _helpers.tpl should convert this to a str
+
+## Pre-load pgAdmin4 with servers at first start-up.
+## Servers are imported only the first time the config DB is created.
+## Docs: https://www.pgadmin.org/docs/pgadmin4/latest/import_export_servers.html
+##
+serverDefinitions:
+  # Enable/disable server import
+  enabled: true
+
+  # Storage for the server JSON:
+  #   ConfigMap - plain text (good for non-secret data)
+  #   Secret    - base-64 (better for credentials)
+  resourceType: Secret
+
+  # Set to true to put raw JSON under `stringData` (handy for dry-runs/debug).
+  # Leave false to keep the default base-64 in `data`.
+  useStringData: true
+
+  # Inline server definitions (ignore if you point to an existing resource)
+  # You can use Helm templates here, e.g. Host: "{{ .Values.example.host }}"
+  servers:
+    1:
+      Name: "Minimally Defined Server"
+      Group: "Server Group 1"
+      Port: '{{ .Values.example.port }}'
+      Username: "postgres"
+      Host: "{{ .Values.example.host }}"
+      MaintenanceDB: '{{ .Values.example.maintenancedb }}'
+      ConnectionParameters: {
+        "sslmode": "prefer",
+        "connect_timeout": '{{ .Values.example.timeout }}'
+      }
+    2:
+     Name: "Fully Defined Server"
+     Group: "Server Group 2"
+     Host: "host.domain.com"
+     Port: "{{ .Values.example.port }}"
+     MaintenanceDB: "postgres"
+     Username: "postgres"
+     Role: "my_role_name"
+     Comment: "This server has every option configured in the JSON"
+     DBRestriction: "live_db test_db"
+     Shared: false
+     SharedUsername: "postgres"
+     BGColor: "#ff9900"
+     FGColor: "#000000"
+     Service: "postgresql-10"
+     UseSSHTunnel: 1
+     TunnelHost: "192.168.1.253"
+     TunnelPort: 22
+     TunnelUsername: "username"
+     TunnelAuthentication: 1
+     TunnelIdentityFile: "/Users/<user>/.ssh/id_rsa.pub"
+     TunnelKeepAlive: 30
+     PasswordExecCommand: "echo 'test'"
+     PasswordExecExpiration: 100
+     KerberosAuthentication: true
+     ConnectionParameters: {
+       "sslmode": "prefer",
+       "connect_timeout": 10,
+       "passfile": "/Users/<user>/.pgpass",
+       "sslcert": "/Users/<user>/.ssh/cert"
+     }
+     Tags: [
+       {
+         "color": "#EC0BB4",
+         "text": "Development"
+       }
+     ]
+     PostConnectionSQL: "set timezone='America/New_York'"

--- a/charts/pgadmin4/templates/server-definitions-configmap.yaml
+++ b/charts/pgadmin4/templates/server-definitions-configmap.yaml
@@ -1,5 +1,4 @@
-{{- if not .Values.serverDefinitions.existingConfigmap -}}
-{{- if and (.Values.serverDefinitions.enabled) (eq .Values.serverDefinitions.resourceType "ConfigMap") (.Values.serverDefinitions.servers) }}
+{{- if and .Values.serverDefinitions.enabled (eq .Values.serverDefinitions.resourceType "ConfigMap") .Values.serverDefinitions.servers (not .Values.serverDefinitions.existingConfigmap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,6 +8,5 @@ metadata:
     {{- include "pgadmin.labels" . | nindent 4 }}
 data:
   servers.json: |-
-{{ include "pgadmin.serverDefinitions" . | indent 4 }}
-{{- end }}
+    {{ include "pgadmin.serverDefinitions" . | nindent 4 | trim }}
 {{- end }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -7,7 +7,12 @@ metadata:
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
-{{- $servers := include "pgadmin.serverDefinitions" . }}
-{{- $block := ternary (printf "stringData:\n  servers.json: |-\n%s" ($servers | indent 4)) (printf "data:\n  servers.json: %s" ($servers | b64enc | quote)) .Values.serverDefinitions.useStringData }}
-{{ $block }}
+{{- if .Values.serverDefinitions.useStringData }}
+stringData:
+  servers.json: |-
+    {{- include "pgadmin.serverDefinitions" . | trim | nindent 4 }}
+{{- else }}
+data:
+  servers.json: {{ include "pgadmin.serverDefinitions" . | trim | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -114,7 +114,7 @@ serverDefinitions:
   #    Group: "Servers"
   #    Username: "postgres"
   #    Host: "{{ .Values.example.host }}"
-  #    Port: {{ .Values.example.port }}
+  #    Port: "{{ .Values.example.port }}"
   #    SSLMode: "prefer"
   #    MaintenanceDB: "postgres"
 


### PR DESCRIPTION
Because Helm feeds raw YAML to the YAML parser before it ever sees any
Go-template syntax, we need to quote the port part. Else it results in:

```
Error: cannot load values.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.example.port":interface {}(nil)}
```
