### PR TITLE
[pgadmin4] Allow tpl of the ingress annotations, both string and map types

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.39.2
+version: 1.39.4
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -14,7 +14,9 @@ metadata:
     {{- with .Values.ingress.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  annotations: {{- tpl (ternary .Values.ingress.annotations (.Values.ingress.annotations | toYaml) (kindIs "string" .Values.ingress.annotations)) . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations: {{- tpl (ternary . (. | toYaml) (kindIs "string" .)) $ | nindent 4 }}
+  {{- end }}
 spec:
 {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
   ingressClassName: {{ .Values.ingress.ingressClassName }}

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -15,10 +15,7 @@ metadata:
   namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  annotations: {{- tpl (ternary .Values.ingress.annotations (.Values.ingress.annotations | toYaml) (kindIs "string" .Values.ingress.annotations)) . | nindent 4 }}
 spec:
 {{- if and .Values.ingress.ingressClassName (semverCompare ">=1.18-0" $kubeVersion) }}
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}


### PR DESCRIPTION
This PR allows the tpl templating of the ingress annotations with both string and map types.
All examples are correct:

```
myAnnotationKey: myAnnotationValue

ingress:
  enabled: true
  annotations:
    myAnnotation: '{{ .Values.myAnnotationKey }}'
```

```
mymap:
  keyA: valueA
  keyB: valueB

ingress:
  enabled: true
  annotations: '{{ .Values.mymap | toYaml }}'
```

```
ingress:
  enabled: true
  annotations:
    myAnnotation: myValue
```