### PR TITLE
refactor(pgadmin4): move ingress API logic to _helpers.tpl

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.39.2
+version: 1.40.0
 appVersion: "9.2"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -79,9 +79,12 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `networkPolicy.enabled` | Enables Network Policy | `true` |
 | `ingress.enabled` | Enables Ingress | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.ingressClassName` | Ingress class name | `""` |
+| `ingress.labels` | Custom labels | `{}` |
+| `ingress.ingressClassName` | Ingress Class Name. MAY be required for Kubernetes versions >= 1.18 | `""` |
 | `ingress.hosts.host` | Ingress accepted hostname | `nil` |
 | `ingress.hosts.paths` | Ingress paths list | `[]` |
+| `ingress.hosts.paths.path` | Ingress accepted path | `/` |
+| `ingress.hosts.paths.pathType` | Ingress type of path | `Prefix` |
 | `ingress.tls` | Ingress TLS configuration | `[]` |
 | `extraConfigmapMounts` | Additional configMap volume mounts for pgadmin4 pod | `[]` |
 | `extraSecretMounts` | Additional secret volume mounts for pgadmin4 pod | `[]` |

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -1,28 +1,29 @@
 {{- if .Values.ingress.enabled -}}
+{{- $ingressApiIsStable := eq (include "pgadmin.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "pgadmin.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "pgadmin.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "pgadmin.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- $kubeVersion := .Capabilities.KubeVersion.Version -}}
-{{- if semverCompare ">=1.19-0" $kubeVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare "<=1.13-0" $kubeVersion -}}
-apiVersion: extensions/v1beta1
-{{- else -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+apiVersion: {{ include "pgadmin.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
   labels:
     {{- include "pgadmin.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if and .Values.ingress.ingressClassName (semverCompare ">=1.18-0" $kubeVersion) }}
-  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
-{{- end }}
+{{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end -}}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -42,11 +43,11 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ .path }}
-          {{- if and .pathType (semverCompare ">=1.18-0" $kubeVersion) }}
-            pathType: {{ .pathType }}
+          {{- if $ingressSupportsPathType }}
+            pathType: {{ .ingressPathType }}
           {{- end }}
             backend:
-            {{- if semverCompare ">=1.19-0" $kubeVersion }}
+            {{- if $ingressApiIsStable }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -125,10 +125,13 @@ networkPolicy:
 ## Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
-  className: ""
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels: {}
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
* Moved ingress apiVersion logic into _helpers.tpl with stable version check
* Moved ingressClassName and pathType support checks into _helpers.tpl using semverCompare >= 1.18.0
* Updated README.md to reflect changes
* Reverted values.yaml example to use ingressClassName with link to the docs (#288)
