### PR TITLE
Fix newline in pgadmin image template

### DIFF
--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -60,9 +60,9 @@ Return full image path using global or local registry.
 {{- $registry := .Values.global.imageRegistry | default .Values.image.registry | trimSuffix "/" }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- if $registry }}
-{{ printf "%s/%s:%s" $registry .Values.image.repository $tag }}
+{{- printf "%s/%s:%s" $registry .Values.image.repository $tag -}}
 {{- else }}
-{{ printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixes an issue with the pgadmin4 chart where a newline character appears in the rendered image value in the deployment template. This causes the image reference to be malformed, potentially preventing the container from starting properly.

The fix adds the missing `-` character in the `pgadmin.image` helper function in _helpers.tpl to properly trim whitespace and prevent the newline from appearing in the output.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:
I've tested this change locally using `helm template` and confirmed that it resolves the issue with the newline character in the image reference.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
