### PR TITLE
remove blank line from image variable

### DIFF
--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -60,9 +60,9 @@ Return full image path using global or local registry.
 {{- $registry := .Values.global.imageRegistry | default .Values.image.registry | trimSuffix "/" }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- if $registry }}
-{{ printf "%s/%s:%s" $registry .Values.image.repository $tag }}
+{{- printf "%s/%s:%s" $registry .Values.image.repository $tag }}
 {{- else }}
-{{ printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
remove blank line from image variable, otherwise it'll be like this in final deployemnt:
    containers:
        - name: pgadmin4 image: "\ndocker.io/dpage/pgadmin4:9.2"

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
