### PR TITLE
fix(pgadmin4): image parsing bug

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.41.0
+version: 1.41.1
 appVersion: 9.2
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -60,9 +60,9 @@ Return full image path using global or local registry.
 {{- $registry := .Values.global.imageRegistry | default .Values.image.registry | trimSuffix "/" }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- if $registry }}
-{{ printf "%s/%s:%s" $registry .Values.image.repository $tag }}
+{{- printf "%s/%s:%s" $registry .Values.image.repository $tag }}
 {{- else }}
-{{ printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository $tag }}
 {{- end }}
 {{- end }}
 

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -22,7 +22,7 @@ image:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
   #  - RegistryKeySecret
-  
+
 ## Deployment annotations
 annotations: {}
 


### PR DESCRIPTION
previous:
```
      containers:
        - name: pgadmin4
          image: "\ndocker.io/dpage/pgadmin4:9.2"
```

after this commit:
```
      containers:
        - name: pgadmin4
          image: "docker.io/dpage/pgadmin4:9.2"
```

Was pointed out in #293 and #295, thank you very much! Both pull request could not be merged - so quickly made this one to fix it.
