### PR TITLE
fix(pgadmin4): fix image tag formatting pgadmin.image template

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.41.1
+version: 1.41.2
 appVersion: 9.2
 keywords:
   - pgadmin

--- a/charts/pgadmin4/templates/_helpers.tpl
+++ b/charts/pgadmin4/templates/_helpers.tpl
@@ -60,9 +60,9 @@ Return full image path using global or local registry.
 {{- $registry := .Values.global.imageRegistry | default .Values.image.registry | trimSuffix "/" }}
 {{- $tag := .Values.image.tag | default .Chart.AppVersion }}
 {{- if $registry }}
-{{- printf "%s/%s:%s" $registry .Values.image.repository $tag }}
+{{- printf "%s/%s:%v" $registry .Values.image.repository $tag }}
 {{- else }}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%v" .Values.image.repository $tag }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This PR fixes a type mismatch issue in the pgadmin.image helm template, this should fix #297.

We now use %v instead of %s in printf to properly handle non-string types without introducing extra quotes
