### PR TITLE
[pgadmin4] Empty password will be randomized

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.42.0
-appVersion: 9.3
+version: 1.42.1
+appVersion: "9.3"
 keywords:
   - pgadmin
   - postgres

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -96,7 +96,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `secretKeys.pgadminPasswordKey` | Name of key in existing secret to use for default pgadmin credentials. Only used when `existingSecret` is set. | `"password"` |
 | `extraInitContainers` | Sidecar init containers to add to the pgadmin4 pod  | `"[]"` |
 | `env.email` | pgAdmin4 default email. Needed chart reinstall for apply changes | `chart@domain.com` |
-| `env.password` | pgAdmin4 default password. Needed chart reinstall for apply changes | `SuperSecret` |
+| `env.password` | pgAdmin4 default password. Needed chart reinstall for apply changes | `""` |
 | `env.pgpassfile` | Path to pgpasssfile (optional). Needed chart reinstall for apply changes | `` |
 | `env.enhanced_cookie_protection` | Allows pgAdmin4 to create session cookies based on IP address | `"False"` |
 | `env.contextPath` | Context path for accessing pgadmin (optional) | `` |

--- a/charts/pgadmin4/templates/auth-secret.yaml
+++ b/charts/pgadmin4/templates/auth-secret.yaml
@@ -9,5 +9,5 @@ metadata:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}
+  password: {{ default (now | unixEpoch | sha256sum | b64enc | trunc 12) .Values.env.password | b64enc | quote }}
 {{- end }}

--- a/charts/pgadmin4/templates/auth-secret.yaml
+++ b/charts/pgadmin4/templates/auth-secret.yaml
@@ -1,5 +1,6 @@
 {{- if not .Values.existingSecret }}
 {{- $fullName := include "pgadmin.fullname" . -}}
+{{- $previous := lookup "v1" "Secret" (include "pgadmin.namespaceName" .) (include "pgadmin.fullname" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,5 +10,5 @@ metadata:
     {{- include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
 data:
-  password: {{ default (now | unixEpoch | sha256sum | b64enc | trunc 12) .Values.env.password | b64enc | quote }}
+  password: {{ coalesce .Values.env.password ($previous.data.password | b64dec) (now | unixEpoch | sha256sum | b64enc | trunc 12) | b64enc | quote }}
 {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -206,7 +206,7 @@ secretKeys:
 env:
   # can be email or nickname
   email: chart@domain.com
-  password: SuperSecret
+  password: ""
   # pgpassfile: /var/lib/pgadmin/storage/pgadmin/file.pgpass
 
   # set context path for application (e.g. /pgadmin4/*)


### PR DESCRIPTION
[pgadmin4] Making empty password to be generated

Making empty password to be generated randomly.
The default password will be empty so it will be generated.
Using the function `(now | unixEpoch | sha256sum | b64enc | trunc 12)` to generate it instead of randAlphaNum function because it must be deterministic to preserve the output for the checksum/secret annotation.

If a password already exist in the secret and the value of env.password is empty it won't change the password and remain as it was while using lookup function.