### PR TITLE
[pgadmin4] password warning, and existing secret fix

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.42.0
-appVersion: 9.3
+version: 1.42.1
+appVersion: "9.3"
 keywords:
   - pgadmin
   - postgres

--- a/charts/pgadmin4/templates/NOTES.txt
+++ b/charts/pgadmin4/templates/NOTES.txt
@@ -2,6 +2,11 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
+{{ if and (eq .Values.env.password "SuperSecret") (empty .Values.existingSecret) }}
+SECURITY WARNING: 'env.password' is set to the default 'SuperSecret' and no 'existingSecret' is set.
+This is insecure. Set a strong password or use an existingSecret.
+{{- end }}
+
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -198,7 +198,7 @@ existingSecret: ""
 ## @param secretKeys.pgadminPasswordKey Name of key in existing secret to use for default pgadmin credentials. Only used when `existingSecret` is set.
 ##
 secretKeys:
-  pgadminPasswordKey: ""
+  pgadminPasswordKey: password
 
 ## pgAdmin4 startup configuration
 ## Values in here get injected as environment variables


### PR DESCRIPTION
As described in #294, a previous commit removed the default key value. This was a mistake at my end, by trying to force security (and then even removing the wrong default value).

I added the default key back, and added a NOTES.txt security warning message if .env.password is left at SuperSecret
