### PR TITLE
[pgadmin4] static port name,extraEnvVars priority, serverDefinitions checksum, README.md fixes, Typos, args and command correct implementation, bad indentation fixes

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.44.0
+version: 1.44.1
 appVersion: "9.3"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.44.1
+version: 1.45.0
 appVersion: "9.3"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.45.1
+version: 1.46.0
 appVersion: "9.3"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/README.md
+++ b/charts/pgadmin4/README.md
@@ -58,15 +58,15 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `revisionHistoryLimit` | The number of old history to retain to allow rollback | `10` |
 | `commonLabels` | Add labels to all the deployed resources | `{}` |
 | `priorityClassName` | Deployment priorityClassName | `""` |
-| `command` | Deployment command override | `""` |
+| `command` | Deployment command override | `[]` |
+| `args` | Deployment args override | `[]` |
 | `service.type` | Service type (ClusterIP, NodePort or LoadBalancer) | `ClusterIP` |
 | `service.clusterIP` | Service type Cluster IP | `""` |
 | `service.loadBalancerIP` | Service Load Balancer IP | `""` |
 | `service.annotations` | Service Annotations | `{}` |
 | `service.port` | Service port | `80` |
-| `service.portName` | Name of the port on the service | `http` |
 | `service.targetPort` | Internal service port | `http` |
-| `service.nodePort` | Kubernetes service nodePort | `` |
+| `service.nodePort` | Kubernetes service nodePort | `""` |
 | `serviceAccount.create` | Creates a ServiceAccount for the pod. | `false` |
 | `serviceAccount.annotations` | Annotations to add to the service account. | `{}` |
 | `serviceAccount.name` | The name of the service account. Otherwise uses the fullname. | `` |
@@ -99,7 +99,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `env.password` | pgAdmin4 default password. Needed chart reinstall for apply changes | `SuperSecret` |
 | `env.pgpassfile` | Path to pgpasssfile (optional). Needed chart reinstall for apply changes | `` |
 | `env.enhanced_cookie_protection` | Allows pgAdmin4 to create session cookies based on IP address | `"False"` |
-| `env.contextPath` | Context path for accessing pgadmin (optional) | `` |
+| `env.contextPath` | Context path for accessing pgadmin | `""` |
 | `envVarsFromConfigMaps` | Array of ConfigMap names to load as environment variables | `[]` |
 | `envVarsFromSecrets` | Array of Secret names to load as environment variables | `[]` |
 | `envVarsExtra` | Array of arbitrary environment variable definitions (e.g., for fetching from Kubernetes Secrets) | `[]` |
@@ -111,6 +111,7 @@ The command removes nearly all the Kubernetes components associated with the cha
 | `persistentVolume.subPath` | Subdirectory of the volume to mount at | `unset` |
 | `securityContext` | Custom [pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pgAdmin4 pod | `` |
 | `containerSecurityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for pgAdmin4 container | `` |
+| `probeScheme` | All Deployments Probe Scheme | `HTTP` |
 | `livenessProbe` | [liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `startupProbe` | [startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |
 | `readinessProbe` | [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) initial delay and timeout | `` |

--- a/charts/pgadmin4/templates/auth-secret.yaml
+++ b/charts/pgadmin4/templates/auth-secret.yaml
@@ -5,8 +5,7 @@ kind: Secret
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
 data:
   password: {{ default "SuperSecret" .Values.env.password | b64enc | quote }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -24,21 +24,24 @@ spec:
         app.kubernetes.io/name: {{ include "pgadmin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- with .Values.podLabels }}
-        {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 8 }}
+        {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | indent 8 }}
         {{- end }}
         {{- with .Values.commonLabels }}
-        {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 8 }}
+        {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | indent 8 }}
         {{- end }}
-    {{- if or (not .Values.existingSecret) .Values.podAnnotations .Values.templatedPodAnnotations }}
+    {{- if or (not .Values.existingSecret) .Values.podAnnotations .Values.templatedPodAnnotations (and .Values.serverDefinitions.enabled (not .Values.serverDefinitions.existingConfigmap) (not .Values.serverDefinitions.existingSecret)) }}
       annotations:
       {{- with .Values.podAnnotations }}
-        {{- . | toYaml | nindent 8 }}
+        {{ . | toYaml | indent 8 }}
       {{- end }}
       {{- with .Values.templatedPodAnnotations }}
-        {{- tpl . $ | nindent 8 }}
+        {{ tpl . $ | indent 8 }}
       {{- end }}
       {{- if not .Values.existingSecret }}
-        checksum/secret: {{ include (print $.Template.BasePath "/auth-secret.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print .Template.BasePath "/auth-secret.yaml") . | sha256sum }}
+      {{- end }}
+      {{- if and .Values.serverDefinitions.enabled (not .Values.serverDefinitions.existingConfigmap) (not .Values.serverDefinitions.existingSecret) }}
+        checksum/server-definitions: {{ include (print .Template.BasePath (printf "/server-definitions-%s.yaml" (lower .Values.serverDefinitions.resourceType))) . | sha256sum }}
       {{- end }}
     {{- end }}
     spec:
@@ -144,7 +147,7 @@ spec:
               value: {{ .Values.env.contextPath }}
           {{- end }}
           {{- if and (.Values.serverDefinitions.enabled) (or (eq .Values.serverDefinitions.resourceType "ConfigMap") (eq .Values.serverDefinitions.resourceType "Secret")) -}}
-          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
+          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.serverDefinitions.servers) }}
             - name: PGADMIN_SERVER_JSON_FILE
               value: /pgadmin4/servers.json
           {{- end }}
@@ -172,7 +175,7 @@ spec:
               mountPath: /var/lib/pgadmin
               subPath: "{{ .Values.persistentVolume.subPath }}"
           {{- if and (.Values.serverDefinitions.enabled) (or (eq .Values.serverDefinitions.resourceType "ConfigMap") (eq .Values.serverDefinitions.resourceType "Secret")) -}}
-          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
+          {{- if or (.Values.serverDefinitions.existingConfigmap) (.Values.serverDefinitions.existingSecret) (.Values.serverDefinitions.servers) }}
             - name: definitions
               mountPath: /pgadmin4/servers.json
               subPath: servers.json
@@ -222,7 +225,7 @@ spec:
         {{- .Values.extraVolumes | toYaml | nindent 8 }}
       {{- end }}
       {{- if and (.Values.serverDefinitions.enabled) (eq .Values.serverDefinitions.resourceType "Secret") -}}
-        {{- if or (.Values.serverDefinitions.existingSecret) (.Values.existingSecret) (.Values.serverDefinitions.servers) }}
+        {{- if or (.Values.serverDefinitions.existingSecret) (.Values.serverDefinitions.servers) }}
         - name: definitions
           secret:
             secretName: {{ include "pgadmin.serverDefinitionsSecret" . }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -4,10 +4,9 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 {{- with .Values.annotations }}
-  annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
+  annotations: {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -84,74 +84,51 @@ spec:
         - name: {{ .Chart.Name }}
           image: {{ include "pgadmin.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.containerSecurityContext.enabled }}
+          {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
-        {{- end }}
-        {{- if .Values.command }}
-          command:
-            {{- toYaml .Values.command | nindent 12 }}
-        {{- end }}
-        {{- if .Values.args }}
-          args:
-            {{- toYaml .Values.args | nindent 12 }}
-        {{- end }}
+          {{- end }}
+          {{- with .Values.command }}
+          command: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args: {{ toYaml . | nindent 12 }}
+          {{- end }}
           ports:
-            - name: {{ .Values.service.portName }}
+            - name: http
               containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
-        {{- if .Values.livenessProbe }}
+          {{- if .Values.livenessProbe }}
           livenessProbe:
             httpGet:
-              port: {{ .Values.service.portName }}
-              {{- if .Values.env.contextPath }}
+              port: http
               path: "{{ .Values.env.contextPath }}/misc/ping"
-              {{- else }}
-              path: /misc/ping
-              {{- end }}
-              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
-              scheme: {{ upper .Values.service.portName }}
-              {{- end }}
+              scheme: {{ .Values.probeScheme }}
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
-        {{- end }}
-        {{- if .Values.startupProbe }}
-          startupProbe:
-            httpGet:
-              port: {{ .Values.service.portName }}
-              {{- if .Values.env.contextPath }}
-              path: "{{ .Values.env.contextPath }}/misc/ping"
-              {{- else }}
-              path: /misc/ping
-              {{- end }}
-              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
-              scheme: {{ upper .Values.service.portName }}
-              {{- end }}
-            {{- .Values.startupProbe | toYaml | nindent 12 }}
-        {{- end }}
-        {{- if .Values.readinessProbe }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
           readinessProbe:
             httpGet:
-              port: {{ .Values.service.portName }}
-              {{- if .Values.env.contextPath }}
+              port: http
               path: "{{ .Values.env.contextPath }}/misc/ping"
-              {{- else }}
-              path: /misc/ping
-              {{- end }}
-              {{- if or (eq (.Values.service.portName | lower) "http") (eq (.Values.service.portName | lower) "https") }}
-              scheme: {{ upper .Values.service.portName }}
-              {{- end }}
+              scheme: {{ .Values.probeScheme }}
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
-        {{- end }}
-          env:
-          {{- with .Values.envVarsExtra }}
-            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.startupProbe }}
+          startupProbe:
+            httpGet:
+              port: http
+              path: "{{ .Values.env.contextPath }}/misc/ping"
+              scheme: {{ .Values.probeScheme }}
+            {{- .Values.startupProbe | toYaml | nindent 12 }}
+          {{- end }}
+          env:
             - name: PGADMIN_CONFIG_ENHANCED_COOKIE_PROTECTION
               value: {{ .Values.env.enhanced_cookie_protection | quote }}
             - name: PGADMIN_DEFAULT_EMAIL
               value: {{ .Values.env.email }}
-          {{- if .Values.env.pgpassfile }}
+          {{- with .Values.env.pgpassfile }}
             - name: PGPASSFILE
-              value: {{ .Values.env.pgpassfile }}
+              value: {{ . }}
           {{- end }}
             - name: PGADMIN_DEFAULT_PASSWORD
               valueFrom:
@@ -176,6 +153,9 @@ spec:
           {{- range .Values.env.variables }}
             - name: {{ .name | quote }}
               value: {{ .value | quote }}
+          {{- end }}
+          {{- with .Values.envVarsExtra }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if or .Values.envVarsFromConfigMaps .Values.envVarsFromSecrets }}
           envFrom:

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         {{- end }}
     {{- if or (not .Values.existingSecret) .Values.podAnnotations .Values.templatedPodAnnotations }}
       annotations:
-      {{- if .Values.podAnnotations }}
-        {{- .Values.podAnnotations | toYaml | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.templatedPodAnnotations }}
         {{- tpl . $ | nindent 8 }}

--- a/charts/pgadmin4/templates/deployment.yaml
+++ b/charts/pgadmin4/templates/deployment.yaml
@@ -24,18 +24,18 @@ spec:
         app.kubernetes.io/name: {{ include "pgadmin.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- with .Values.podLabels }}
-        {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | indent 8 }}
+        {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 8 }}
         {{- end }}
         {{- with .Values.commonLabels }}
-        {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | indent 8 }}
+        {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 8 }}
         {{- end }}
     {{- if or (not .Values.existingSecret) .Values.podAnnotations .Values.templatedPodAnnotations (and .Values.serverDefinitions.enabled (not .Values.serverDefinitions.existingConfigmap) (not .Values.serverDefinitions.existingSecret)) }}
       annotations:
       {{- with .Values.podAnnotations }}
-        {{ . | toYaml | indent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.templatedPodAnnotations }}
-        {{ tpl . $ | indent 8 }}
+        {{- tpl . $ | nindent 8 }}
       {{- end }}
       {{- if not .Values.existingSecret }}
         checksum/secret: {{ include (print .Template.BasePath "/auth-secret.yaml") . | sha256sum }}

--- a/charts/pgadmin4/templates/hpa.yaml
+++ b/charts/pgadmin4/templates/hpa.yaml
@@ -11,8 +11,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "pgadmin.fullname" . }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -48,7 +48,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  number: {{ $svcPort }}
+                  name: http
             {{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -3,7 +3,6 @@
 {{- $ingressSupportsIngressClassName := eq (include "pgadmin.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "pgadmin.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "pgadmin.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
 apiVersion: {{ include "pgadmin.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -50,7 +49,7 @@ spec:
                   name: http
             {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              servicePort: {{ .Values.service.port }}
             {{- end }}
         {{- end }}
   {{- end }}

--- a/charts/pgadmin4/templates/ingress.yaml
+++ b/charts/pgadmin4/templates/ingress.yaml
@@ -9,13 +9,12 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}
     {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
     {{- end }}
   {{- with .Values.ingress.annotations }}
-  annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
+  annotations: {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
 {{- if and $ingressSupportsIngressClassName .Values.ingress.ingressClassName }}

--- a/charts/pgadmin4/templates/networkpolicy.yaml
+++ b/charts/pgadmin4/templates/networkpolicy.yaml
@@ -5,8 +5,7 @@ kind: NetworkPolicy
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 spec:
   policyTypes:
     - Ingress

--- a/charts/pgadmin4/templates/pvc.yaml
+++ b/charts/pgadmin4/templates/pvc.yaml
@@ -5,10 +5,9 @@ apiVersion: v1
 metadata:
   name: {{ $fullName }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.persistentVolume.annotations }}
-  annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
+  annotations: {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
   accessModes:

--- a/charts/pgadmin4/templates/server-definitions-configmap.yaml
+++ b/charts/pgadmin4/templates/server-definitions-configmap.yaml
@@ -4,8 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "pgadmin.fullname" . }}-server-definitions
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 data:
   servers.json: |-
     {{ include "pgadmin.serverDefinitions" . | nindent 4 | trim }}

--- a/charts/pgadmin4/templates/server-definitions-secret.yaml
+++ b/charts/pgadmin4/templates/server-definitions-secret.yaml
@@ -4,8 +4,7 @@ kind: Secret
 metadata:
   name: {{ include "pgadmin.fullname" . }}-server-definitions
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
 type: Opaque
 {{- if .Values.serverDefinitions.useStringData }}
 stringData:

--- a/charts/pgadmin4/templates/service.yaml
+++ b/charts/pgadmin4/templates/service.yaml
@@ -3,9 +3,9 @@ kind: Service
 metadata:
   name: {{ include "pgadmin.fullname" . }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels: {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
-  annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
+  annotations: {{ include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/charts/pgadmin4/templates/service.yaml
+++ b/charts/pgadmin4/templates/service.yaml
@@ -3,8 +3,7 @@ kind: Service
 metadata:
   name: {{ include "pgadmin.fullname" . }}
   namespace: {{ include "pgadmin.namespaceName" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{- include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
   {{- end }}
@@ -19,10 +18,9 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
-    {{- if .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
+    {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
     {{- end }}
       protocol: TCP
-      name: {{ .Values.service.portName }}
-  selector:
-    {{- include "pgadmin.selectorLabels" . | nindent 4 }}
+      name: http
+  selector: {{- include "pgadmin.selectorLabels" . | nindent 4 }}

--- a/charts/pgadmin4/templates/service.yaml
+++ b/charts/pgadmin4/templates/service.yaml
@@ -23,4 +23,4 @@ spec:
     {{- end }}
       protocol: TCP
       name: http
-  selector: {{- include "pgadmin.selectorLabels" . | nindent 4 }}
+  selector: {{ include "pgadmin.selectorLabels" . | nindent 4 }}

--- a/charts/pgadmin4/templates/serviceaccount.yaml
+++ b/charts/pgadmin4/templates/serviceaccount.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pgadmin.fullname" . }}
-  labels:
-    {{- include "pgadmin.labels" . | nindent 4 }}
+  labels: {{ include "pgadmin.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- include "pgadmin.tplToMap" (dict "toMap" . "context" $) | nindent 4 }}
   {{- end }}

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -46,7 +46,7 @@ service:
   clusterIP: ""
   loadBalancerIP: ""
   port: 80
-  targetPort: 80
+  targetPort: http
   # targetPort: 4181 To be used with a proxy extraContainer
   portName: http
 

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -35,11 +35,12 @@ commonLabels: {}
 ## priorityClassName
 priorityClassName: ""
 
-## Deployment entrypoint override
+## Deployment command and args override
 ## Useful when there's a requirement to modify container's default:
 ## https://www.vaultproject.io/docs/platform/k8s/injector/examples#environment-variable-example
 ## ref: https://github.com/postgres/pgadmin4/blob/master/Dockerfile#L206
-# command: "['/bin/sh', '-c', 'source /vault/secrets/config && <entrypoint script>']"
+command: []
+args: []
 
 service:
   type: ClusterIP
@@ -48,7 +49,6 @@ service:
   port: 80
   targetPort: http
   # targetPort: 4181 To be used with a proxy extraContainer
-  portName: http
 
   annotations: {}
     ## Special annotations at the service level, e.g
@@ -58,7 +58,7 @@ service:
   ## Specify the nodePort value for the service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ##
-  # nodePort:
+  nodePort: ""
 
 ## Pod Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -139,7 +139,7 @@ ingress:
   enabled: false
   # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
   # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
-  # ingressClassName: nginx
+  ingressClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -209,8 +209,8 @@ env:
   password: SuperSecret
   # pgpassfile: /var/lib/pgadmin/storage/pgadmin/file.pgpass
 
-  # set context path for application (e.g. /pgadmin4/*)
-  # contextPath: /pgadmin4
+  # set context path for application (e.g. /pgadmin4)
+  contextPath: ""
 
   ## If True, allows pgAdmin4 to create session cookies based on IP address
   ## Ref: https://www.pgadmin.org/docs/pgadmin4/latest/config_py.html
@@ -302,6 +302,9 @@ containerSecurityContext:
 ## pgAdmin4 readiness and liveness probe initial delay and timeout
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ##
+probeScheme: HTTP
+# HTTP / HTTPS, If HTTPS the kubelet must trust the certificate the pgAdmin4 is using
+
 livenessProbe:
   initialDelaySeconds: 30
   periodSeconds: 20


### PR DESCRIPTION
1. Major move to static port name, no one needs that value and its just complicating. In other famous charts its static.
2. Probes Schemes by value instead of naming upper http/https by portName
3. Moving extraEnvVars to the end of the env field to take priority on already existing values
4. Pod Checksum Annotation for the server definitions configmap/secret
5. args value wasn't existing, correct implementation of both command and args values
6. ALOT OF TYPOS
7. README.md FIXES
8. ALOT bad indentations fixes