### PR TITLE
[pgadmin4] Improve probe configuration

### DIFF
--- a/charts/pgadmin4/Chart.yaml
+++ b/charts/pgadmin4/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: pgAdmin4 is a web based administration tool for PostgreSQL database
 name: pgadmin4
-version: 1.50.0
+version: 1.50.1
 appVersion: "9.8"
 keywords:
   - pgadmin

--- a/charts/pgadmin4/values.yaml
+++ b/charts/pgadmin4/values.yaml
@@ -314,24 +314,22 @@ containerSecurityContext:
   enabled: false
   allowPrivilegeEscalation: false
 
-## pgAdmin4 readiness and liveness probe initial delay and timeout
+## pgAdmin4 health check probe configuration 
 ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ##
 livenessProbe:
-  initialDelaySeconds: 30
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 3
 
 readinessProbe:
-  initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 3
   failureThreshold: 3
 
 startupProbe:
-  failureThreshold: 30
-  periodSeconds: 2
+  failureThreshold: 18
+  periodSeconds: 10
 
 ## Required to be enabled pre pgAdmin4 4.16 release, to set the ACL on /var/lib/pgadmin.
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
@@ -361,10 +359,13 @@ containerPorts:
   http: 80
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## You might also want to increase failure threshold value in startup probe configuration to
+  ## allow the container to start successfully on CPU limited environments.
+  ##
   # limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
#### What this PR does / why we need it:
Previous startup probe configuration was a little bit incorrect. It queried a container every 2 seconds for 1 minute expecting it to be started. Even on non limited resources pgAdmin won't start in couple of seconds. This also contributed to longer startup time because of constant querying.

Proposed configuration queries every 10 seconds for a maximum amount of 2 minutes (18 x 10 seconds). This is more inline what to expect from Python application, especially if one enables limited CPU resources in the Helm chart.

PR also removes initialDelay from liveness/readiness probes as it should not be used in conjunction with startup probe. Liveness/Readiness probes are not executed until the container is started and startup probe completes successfully.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[pgadmin4]`)
